### PR TITLE
fdb5 library needs to be shared always

### DIFF
--- a/src/fdb5/CMakeLists.txt
+++ b/src/fdb5/CMakeLists.txt
@@ -368,6 +368,8 @@ endif()
 ecbuild_add_library(
 
     TARGET  fdb5
+    
+    TYPE SHARED # Library needs to be shared for dynamic factory self registration
 
     SOURCES
         ${fdb5_srcs}


### PR DESCRIPTION
Due to reliance on factory self registration this library should never be compiled as static.
This may happen otherwise when CMake configuration with `-DBUILD_SHARED_LIBS=OFF` occurs