### PR TITLE
Feature/fdb 306 dump cleared indexes

### DIFF
--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -386,7 +386,7 @@ bool TocHandler::readNext( TocRecord &r, bool walkSubTocs, bool hideSubTocEntrie
     while (true) {
 
         if (subTocRead_) {
-            len = subTocRead_->readNext(r, walkSubTocs, hideSubTocEntries, hideClearEntries);
+            len = subTocRead_->readNext(r, walkSubTocs, hideSubTocEntries, hideClearEntries, walkClearSubTocs);
             if (len == 0) {
                 subTocRead_.reset();
             } else {
@@ -438,7 +438,7 @@ bool TocHandler::readNext( TocRecord &r, bool walkSubTocs, bool hideSubTocEntrie
 
                 if (hideSubTocEntries) {
                     // The first entry in a subtoc must be the init record. Check that
-                    subTocRead_->readNext(r, walkSubTocs, hideSubTocEntries, hideClearEntries);
+                    subTocRead_->readNext(r, walkSubTocs, hideSubTocEntries, hideClearEntries, walkClearSubTocs);
                     ASSERT(r.header_.tag_ == TocRecord::TOC_INIT);
                 } else {
                     return true; // if not hiding the subtoc entries, return them as normal entries!

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -367,7 +367,7 @@ size_t TocHandler::roundRecord(TocRecord &r, size_t payloadSize) {
 
 // readNext wraps readNextInternal.
 // readNext reads the next TOC entry from this toc, or from an appropriate subtoc if necessary.
-bool TocHandler::readNext( TocRecord &r, bool walkSubTocs, bool hideSubTocEntries, bool hideClearEntries) const {
+bool TocHandler::readNext( TocRecord &r, bool walkSubTocs, bool hideSubTocEntries, bool hideClearEntries, bool walkClearSubTocs) const {
 
     int len;
 
@@ -418,10 +418,17 @@ bool TocHandler::readNext( TocRecord &r, bool walkSubTocs, bool hideSubTocEntrie
                 eckit::PathName absPath = (path.path()[0] == '/') ? findRealPath(path) : (currentDirectory() / path);
 
                 // If this subtoc has a masking entry, then skip it, and go on to the next entry.
+                // Unless walkClearSubTocs is true, in which case walk it if it exists.
                 std::pair<eckit::PathName, size_t> key(absPath, 0);
                 if (maskedEntries_.find(key) != maskedEntries_.end()) {
-                    Log::debug<LibFdb5>() << "SubToc ignored by mask: " << path << std::endl;
-                    continue;
+                    if (!walkClearSubTocs){
+                        Log::debug<LibFdb5>() << "SubToc ignored by mask: " << path << std::endl;
+                        continue;
+                    }
+                    if (!absPath.exists()) {
+                        Log::debug<LibFdb5>() << "SubToc does not exist: " << path << std::endl;
+                        continue;
+                    }
                 }
 
                 eckit::Log::debug<LibFdb5>() << "Opening SUB_TOC: " << absPath << " " << parentKey_ << std::endl;
@@ -1157,7 +1164,8 @@ void TocHandler::dumpIndexFile(std::ostream& out, const eckit::PathName& indexFi
     bool walkSubTocs = true;
     bool hideSubTocEntries = true;
     bool hideClearEntries = true;
-    while ( readNext(*r, walkSubTocs, hideSubTocEntries, hideClearEntries) ) {
+    bool walkClearSubTocs = true;
+    while ( readNext(*r, walkSubTocs, hideSubTocEntries, hideClearEntries, walkClearSubTocs) ) {
 
         eckit::MemoryStream s(&r->payload_[0], r->maxPayloadSize);
         std::string path;

--- a/src/fdb5/toc/TocHandler.h
+++ b/src/fdb5/toc/TocHandler.h
@@ -219,7 +219,10 @@ private: // methods
 
     // hideSubTocEntries=true returns entries as though only one toc existed (i.e. to hide
     // the mechanism of subtocs).
-    bool readNext(TocRecord &r, bool walkSubTocs = true, bool hideSubTocEntries = true, bool hideClearEntries = true) const;
+    // walkClearSubTocs=true will walk subtocs even if they are marked as clear. This is
+    // useful for dumping indexes which are only referred to in cleared subtocs.
+    bool readNext(TocRecord &r, bool walkSubTocs = true, bool hideSubTocEntries = true,
+                  bool hideClearEntries = true, bool walkClearSubTocs = false) const;
 
     bool readNextInternal(TocRecord &r) const;
 


### PR DESCRIPTION
Presently, fdb-dump-index cannot dump information about indexes that are only referred to by subtocs which have been marked as CLEAR. This is problematic, as it means there are no debug tools for extracting information about old indexes without hackily changing the toc.

This change allows fdb-dump-index to search subtocs for the specified index even if the subtoc has been cleared, as long as the subtoc still exists.
