### PR TITLE
Fix attempting to generate auxiliary test when fdb-tools are disabled

### DIFF
--- a/tests/fdb/tools/auxiliary/CMakeLists.txt
+++ b/tests/fdb/tools/auxiliary/CMakeLists.txt
@@ -1,6 +1,9 @@
-ecbuild_configure_file( move_auxiliary.sh.in fdb_move_auxiliary.sh @ONLY )
+if (HAVE_FDB_BUILD_TOOLS)
+    ecbuild_configure_file( move_auxiliary.sh.in fdb_move_auxiliary.sh @ONLY )
 
-ecbuild_add_test(
-    TYPE SCRIPT
-    CONDITION HAVE_FDB_BUILD_TOOLS
-    COMMAND fdb_move_auxiliary.sh)
+    ecbuild_add_test(
+        TYPE SCRIPT
+        CONDITION HAVE_FDB_BUILD_TOOLS
+        COMMAND fdb_move_auxiliary.sh)
+endif()
+


### PR DESCRIPTION
Wrap the configure_file command in an if(HAVE_FDB_BUILD_TOOLS) block.