### PR TITLE
Add Axes support to SelectFDB

### DIFF
--- a/src/fdb5/api/FDB.cc
+++ b/src/fdb5/api/FDB.cc
@@ -301,11 +301,15 @@ void FDB::flush() {
 IndexAxis FDB::axes(const FDBToolRequest& request, int level) {
     IndexAxis axes;
     AxesElement elem;
-    auto it = internal_->axes(request, level);
+    auto it = axesIterator(request, level);
     while (it.next(elem)) {
         axes.merge(elem.axes());
     }
     return axes;
+}
+
+AxesIterator FDB::axesIterator(const FDBToolRequest& request, int level) {
+    return internal_->axesIterator(request, level);
 }
 
 bool FDB::dirty() const {

--- a/src/fdb5/api/FDB.h
+++ b/src/fdb5/api/FDB.h
@@ -33,6 +33,7 @@
 #include "fdb5/api/helpers/StatusIterator.h"
 #include "fdb5/api/helpers/WipeIterator.h"
 #include "fdb5/api/helpers/MoveIterator.h"
+#include "fdb5/api/helpers/AxesIterator.h"
 #include "fdb5/config/Config.h"
 #include "fdb5/api/helpers/Callback.h"
 
@@ -114,6 +115,8 @@ public: // methods
                             ControlIdentifiers identifiers);
 
     IndexAxis axes(const FDBToolRequest& request, int level=3);
+
+    AxesIterator axesIterator(const FDBToolRequest& request, int level=3);
 
     bool enabled(const ControlIdentifier& controlIdentifier) const;
 

--- a/src/fdb5/api/FDBFactory.h
+++ b/src/fdb5/api/FDBFactory.h
@@ -89,7 +89,7 @@ public: // methods
 
     virtual MoveIterator move(const FDBToolRequest& request, const eckit::URI& dest) = 0;
 
-    virtual AxesIterator axes(const FDBToolRequest& request, int axes) { NOTIMP; }
+    virtual AxesIterator axesIterator(const FDBToolRequest& request, int axes) { NOTIMP; }
 
     void registerArchiveCallback(ArchiveCallback callback) {callback_ = callback;}
 

--- a/src/fdb5/api/LocalFDB.cc
+++ b/src/fdb5/api/LocalFDB.cc
@@ -125,8 +125,8 @@ ControlIterator LocalFDB::control(const FDBToolRequest& request,
     return queryInternal<ControlVisitor>(request, action, identifiers);
 }
 
-AxesIterator LocalFDB::axes(const FDBToolRequest& request, int level) {
-    LOG_DEBUG_LIB(LibFdb5) << "LocalFDB::axes() : " << request << std::endl;
+AxesIterator LocalFDB::axesIterator(const FDBToolRequest& request, int level) {
+    LOG_DEBUG_LIB(LibFdb5) << "LocalFDB::axesIterator() : " << request << std::endl;
     return queryInternal<AxesVisitor>(request, config_, level);
 }
 

--- a/src/fdb5/api/LocalFDB.h
+++ b/src/fdb5/api/LocalFDB.h
@@ -59,7 +59,7 @@ public: // methods
 
     MoveIterator move(const FDBToolRequest& request, const eckit::URI& dest) override;
 
-    AxesIterator axes(const FDBToolRequest& request, int axes) override;
+    AxesIterator axesIterator(const FDBToolRequest& request, int axes) override;
 
     void flush() override;
 

--- a/src/fdb5/api/SelectFDB.cc
+++ b/src/fdb5/api/SelectFDB.cc
@@ -196,6 +196,14 @@ ControlIterator SelectFDB::control(const FDBToolRequest& request,
     });
 }
 
+AxesIterator SelectFDB::axesIterator(const FDBToolRequest& request, int level) {
+    LOG_DEBUG_LIB(LibFdb5) << "SelectFDB::axesIterator() >> " << request << std::endl;
+    return queryInternal(request,
+                         [level](FDB& fdb, const FDBToolRequest& request) {
+                            return fdb.axesIterator(request, level);
+    });
+}
+
 void SelectFDB::flush() {
     for (auto& iter : subFdbs_) {
         FDB& fdb(iter.second);

--- a/src/fdb5/api/SelectFDB.h
+++ b/src/fdb5/api/SelectFDB.h
@@ -68,6 +68,8 @@ public: // methods
     
     MoveIterator move(const FDBToolRequest& request, const eckit::URI& dest) override { NOTIMP; }
 
+    AxesIterator axesIterator(const FDBToolRequest& request, int level) override;
+
     void flush() override;
 
 private: // methods


### PR DESCRIPTION
Involved creation of two seperate functions: AxesIterator (returns an AxesIterator) and Axes (returns an IndexAxis).

Internal FDB objects only implement AxesIterator.