### PR TITLE
Fix ignored config flag in fdb-purge

### DIFF
--- a/src/fdb5/tools/fdb-purge.cc
+++ b/src/fdb5/tools/fdb-purge.cc
@@ -61,9 +61,7 @@ void FDBPurge::init(const CmdArgs& args) {
 }
 
 void FDBPurge::execute(const CmdArgs& args) {
-
-    FDB fdb;
-
+    FDB fdb(config(args));
     for (const FDBToolRequest& request : requests()) {
 
         if (!porcelain_) {


### PR DESCRIPTION
'fdb-purge' is now using the '--config' flag as advertised in '--help'