### PR TITLE
Add datareader_size to C api

### DIFF
--- a/src/fdb5/api/fdb_c.cc
+++ b/src/fdb5/api/fdb_c.cc
@@ -193,6 +193,10 @@ public:
         ASSERT(dh_);
         return dh_->read(buf, length);
     }
+    long size() {
+        ASSERT(dh_);
+        return dh_->size();
+    }
     void set(DataHandle* dh) {
         if (dh_)
             delete dh_;
@@ -552,6 +556,12 @@ int fdb_datareader_read(fdb_datareader_t* dr, void *buf, long count, long* read)
         ASSERT(buf);
         ASSERT(read);
         *read = dr->read(buf, count);
+    });
+}
+int fdb_datareader_size(fdb_datareader_t* dr, long* size) {
+    return wrapApiFunction([=]{
+        ASSERT(dr);
+        *size = dr->size();
     });
 }
 int fdb_delete_datareader(fdb_datareader_t* dr) {

--- a/src/fdb5/api/fdb_c.h
+++ b/src/fdb5/api/fdb_c.h
@@ -279,6 +279,13 @@ int fdb_datareader_seek(fdb_datareader_t* dr, long pos);
  */
 int fdb_datareader_skip(fdb_datareader_t* dr, long count);
 
+/** Return size of internal datahandle in bytes.
+ * \param dr DataReader instance
+ * \param size Size of the DataReader
+ * \returns Return code (#FdbErrorValues)
+ */
+int fdb_datareader_size(fdb_datareader_t* dr, long* size);
+
 /** Read binary data from a DataReader to a given memory buffer.
  * \param dr DataReader instance
  * \param buf Pointer of the target memory buffer.


### PR DESCRIPTION
Add size to the datareader API. This makes it a lot easier to read the full blob from pyfdb.retrieve()