### PR TITLE
Add .clang-tidy config with minimal checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: "-*, readability-delete-null-pointer"
+WarningsAsErrors:             true
+HeaderFileExtensions:         ['', 'h','hh','hpp','hxx']
+ImplementationFileExtensions: ['c','cc','cpp','cxx']
+HeaderFilterRegex:            ''
+FormatStyle:                  none
+InheritParentConfig:          false

--- a/src/fdb5/api/fdb_c.cc
+++ b/src/fdb5/api/fdb_c.cc
@@ -9,7 +9,6 @@
  */
 
 #include "eckit/io/MemoryHandle.h"
-#include "eckit/io/FileDescHandle.h"
 #include "eckit/message/Message.h"
 #include "eckit/runtime/Main.h"
 #include "eckit/config/YAMLConfiguration.h"
@@ -66,8 +65,8 @@ public:
         Tokenizer parse("/");
 
         for (int i=0; i<numValues; i++) {
-        	std::vector<std::string> result;
-        	parse(values[i], result);
+            std::vector<std::string> result;
+            parse(values[i], result);
             vv.insert(std::end(vv), std::begin(result), std::end(result));
         }
         request_.values(n, vv);
@@ -110,7 +109,7 @@ public:
             } else {
                 return FDB_ITERATION_COMPLETE;
             }
-        } 
+        }
         while (it_ == key_->at(level_).end()) {
             if (level_<key_->size()-1) {
                 level_++;
@@ -198,11 +197,10 @@ public:
         return dh_->size();
     }
     void set(DataHandle* dh) {
-        if (dh_)
-            delete dh_;
+        delete dh_;
         dh_ = dh;
     }
-    
+
 private:
     DataHandle* dh_;
 };

--- a/src/fdb5/database/Report.h
+++ b/src/fdb5/database/Report.h
@@ -17,6 +17,7 @@
 #define fdb5_Report_H
 
 #include <map>
+#include <set>
 
 #include "eckit/memory/NonCopyable.h"
 


### PR DESCRIPTION
The commited .clang-tidy file contains only a single check and no automated tidy runs are done.

The added check is readability-delete-null-pointer, i.e. tidy warns on superflous nullptr check before calling delete.

This commit also fixes a missing include in Report.h because this clang-tidy would otherwise report this tempalte instanciation as erroneous.