### PR TITLE
New tidy rule bugprone parent virtual call / Shell script to execute clang-tidy conveniently

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,13 @@
 ---
-Checks: "-*, readability-delete-null-pointer"
-WarningsAsErrors:             true
+UseColor: On
+Checks: >-
+  -*,
+  readability-delete-null-pointer,
+  bugprone-parent-virtual-call,
+
+WarningsAsErrors:             false
 HeaderFileExtensions:         ['', 'h','hh','hpp','hxx']
 ImplementationFileExtensions: ['c','cc','cpp','cxx']
-HeaderFilterRegex:            ''
+HeaderFilterRegex:            '.*'
 FormatStyle:                  none
 InheritParentConfig:          false

--- a/run-clang-tidy
+++ b/run-clang-tidy
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+tidy_path=${TIDY_PATH:-clang-tidy}
+
+function print_usage() {
+    echo "Usage: run-clang-tidy <BUILD-FOLDER>"
+    echo "  - This script depends on clang-tidy, jq and parallel all need to be on PATH"
+    echo "  - You can supply a custom clang-tidy path by exporting TIDY_PATH 
+    echo "  - Note that you need to have used cmake with CMAKE_EXPORT_COMPILE_COMMANDS=ON and"
+    echo "    you will have needed to build sources once to generate headers files that otherwise"
+    echo "    cannot be found, e.g. 'metkit/mars/StepRange.b'
+}
+
+function ensure_bin() {
+    local _binary="${1}" 
+    if ! command -v "${_binary}" 2>&1 >/dev/null
+    then
+        echo "Mising executable ${_binary}!"
+        print_usage
+        exit 1
+    fi
+}
+
+if [ $# -ne 1 ]
+then
+    print_usage
+    exit 1
+fi
+build_path="${1}"
+
+ensure_bin parallel
+ensure_bin jq 
+ensure_bin "${tidy_path}"
+
+cat ${build_path}/compile_commands.json | jq -r '.[].file | select(contains("/fdb/"))' | parallel "${tidy_path}" -p ${build_path} {}

--- a/src/fdb5/tools/fdb-wipe.cc
+++ b/src/fdb5/tools/fdb-wipe.cc
@@ -65,8 +65,6 @@ void FDBWipe::usage(const std::string &tool) const {
                 << tool << " class=rd,expver=xywz,stream=oper,date=20190603,time=00"
                 << std::endl
                 << std::endl;
-
-    FDBTool::usage(tool);
 }
 
 void FDBWipe::init(const CmdArgs &args) {


### PR DESCRIPTION
# Description

As discussed yesterday shortly in the FDB chat a short shell script to invoke clang-tidy.

## Add new tidy rule 

(https://github.com/ecmwf/fdb/commit/0a09f17a1c202661095e62f5beafee75db97d181) 
Added bugprone-parent-virtual-call, for a detailed explanation see:
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/parent-virtual-call.html

Further this commit also fixes one found issue.


## Add simple shell script to run clang tidy

(https://github.com/ecmwf/fdb/commit/558cb5f2157ae3428af55e33eb1b52b3db28450c) 
Although clang tidy uses compile commands json to find referenced
headers it still cannot be used as input to find the files to analyse.
This script uses jq to constrain checking to the files that are
actually compiled by your cmake configuration, i.e. the files
referenced in compile_commands.json

run-clang-tidy script requires the following programs to be
installed:
 - jq -> parsing the compile commands json
 - parallel -> parallelise execution
 - clang-tidy

Usage example, call from anywhere:
```
    > ./run-clang-tidy <build-path>
```
Alternatively supply a specific location if clang-tidy is not on PATH
```
    > TIDY_PATH=/opt/homebrew/opt/llvm/bin/clang-tidy \
        ./run-clang-tidy <build-path>
```
