### PR TITLE
Base tmpdir on cwd in auxiliary/callback tests

### DIFF
--- a/tests/fdb/api/test_auxiliary.cc
+++ b/tests/fdb/api/test_auxiliary.cc
@@ -1,5 +1,6 @@
 #include "eckit/testing/Test.h"
 #include "eckit/filesystem/TmpDir.h"
+#include "eckit/filesystem/LocalPathName.h"
 #include "metkit/mars/MarsRequest.h"
 #include "fdb5/api/FDB.h"
 #include "fdb5/api/helpers/FDBToolRequest.h"
@@ -64,8 +65,7 @@ std::set<eckit::PathName> setup(FDB& fdb) {
 //----------------------------------------------------------------------------------------------------------------------
 
 CASE("Wipe with extensions") {
-
-    eckit::TmpDir tmpdir;
+    eckit::TmpDir tmpdir(eckit::LocalPathName::cwd().c_str());
     eckit::testing::SetEnv env_config{"FDB_ROOT_DIRECTORY", tmpdir.asString().c_str()};
 
     eckit::testing::SetEnv env_extensions{"FDB_AUX_EXTENSIONS", "foo,bar"};
@@ -93,8 +93,7 @@ CASE("Wipe with extensions") {
 }
 
 CASE("Purge with extensions") {
-
-    eckit::TmpDir tmpdir;
+    eckit::TmpDir tmpdir(eckit::LocalPathName::cwd().c_str());
     eckit::testing::SetEnv env_config{"FDB_ROOT_DIRECTORY", tmpdir.asString().c_str()};
 
     eckit::testing::SetEnv env_extensions{"FDB_AUX_EXTENSIONS", "foo,bar"};

--- a/tests/fdb/api/test_callback.cc
+++ b/tests/fdb/api/test_callback.cc
@@ -1,5 +1,6 @@
 #include "eckit/testing/Test.h"
 #include "eckit/filesystem/TmpDir.h"
+#include "eckit/filesystem/LocalPathName.h"
 #include "fdb5/api/FDB.h"
 
 namespace fdb5::test {
@@ -7,7 +8,7 @@ namespace fdb5::test {
 //----------------------------------------------------------------------------------------------------------------------
 CASE("Archive and flush callback") {
 
-    eckit::TmpDir tmpdir;
+    eckit::TmpDir tmpdir(eckit::LocalPathName::cwd().c_str());
     eckit::testing::SetEnv env_config{"FDB_ROOT_DIRECTORY", tmpdir.asString().c_str()};
 
     FDB fdb;


### PR DESCRIPTION
In response to issue introduced by PR https://github.com/ecmwf/fdb/pull/43 . We cannot use $TMPDIR when tests when FDB has been configured to use a Lustre filesystem when $TMPDIR is not itself Lustre. 

This PR causes affected tests to write to the test directory instead.