### PR TITLE
Copy DenseSet in IndexAxis.merge

### DIFF
--- a/src/fdb5/database/IndexAxis.cc
+++ b/src/fdb5/database/IndexAxis.cc
@@ -388,7 +388,8 @@ void IndexAxis::merge(const fdb5::IndexAxis& other) {
 
         auto it = axis_.find(kv.first);
         if (it == axis_.end()) {
-            axis_.emplace(kv.first, kv.second);
+            /// @note: Have to make a copy, otherwise we risk modifying cached axes in the AxisRegistry.
+            axis_.emplace(kv.first, std::make_shared<eckit::DenseSet<std::string>>(*kv.second));
         } else {
             it->second->merge(*kv.second);
         };


### PR DESCRIPTION
Fixes seg fault https://github.com/ecmwf/fdb/issues/62.
We found a consistent clientside seg fault when using fdb-axes on the databridge. e.g. `fdb-axes class=d1,param=167,step=0,expver=0001,dataset=extremes-dt,levtype=sfc,stream=oper,type=fc` would seg fault.

The problem:
When you call `axis.merge(some_read_only_axis)`, the `axis` object gains shared ownership of the read only object's denseset, allowing it to be modified. This corrupts the axis registry which makes assumptions that require its cached axis to be read only.

This fix makes a copy of the axis when first merging, rather than sharing ownership.