### PR TITLE
Adds fdb-overlay support to remote FDB

### DIFF
--- a/src/fdb5/daos/DaosCatalogueWriter.h
+++ b/src/fdb5/daos/DaosCatalogueWriter.h
@@ -37,7 +37,7 @@ public: // methods
     /// Mount an existing TocCatalogue, which has a different metadata key (within
     /// constraints) to allow on-line rebadging of data
     /// variableKeys: The keys that are allowed to differ between the two DBs
-    void overlayDB(const Catalogue& otherCatalogue, const std::set<std::string>& variableKeys, bool unmount) override { NOTIMP; };
+    void overlayDB(const Catalogue* srcCatalogue, const eckit::StringSet& variableKeys, bool unmount) override { NOTIMP; };
 
 //     // Hide the contents of the DB!!!
 //     void hideContents() override;

--- a/src/fdb5/database/Catalogue.h
+++ b/src/fdb5/database/Catalogue.h
@@ -137,7 +137,7 @@ class CatalogueReader : virtual public Catalogue {
 public:
 
     CatalogueReader() {}
-    
+
     virtual ~CatalogueReader() {}
 
     virtual DbStats stats() const = 0;
@@ -156,7 +156,7 @@ public:
     virtual const Index& currentIndex() = 0;
     virtual const Key currentIndexKey();
     virtual void archive(const Key& idxKey, const Key& datumKey, std::shared_ptr<const FieldLocation> fieldLocation) = 0;
-    virtual void overlayDB(const Catalogue& otherCatalogue, const std::set<std::string>& variableKeys, bool unmount) = 0;
+    virtual void overlayDB(const Catalogue* srcCatalogue, const eckit::StringSet& variableKeys, bool unmount) = 0;
     virtual void index(const Key& key, const eckit::URI& uri, eckit::Offset offset, eckit::Length length) = 0;
     virtual void reconsolidate() = 0;
 };

--- a/src/fdb5/remote/Connection.cc
+++ b/src/fdb5/remote/Connection.cc
@@ -12,8 +12,6 @@ namespace fdb5::remote {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Connection::Connection() : single_(false) { }
-
 void Connection::teardown() {
 
     if (!single_) {

--- a/src/fdb5/remote/Connection.h
+++ b/src/fdb5/remote/Connection.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "eckit/serialisation/MemoryStream.h"
 #include "fdb5/remote/Messages.h"
 
 #include "eckit/exception/Exceptions.h"
@@ -52,7 +51,7 @@ public:  // types
     using PayloadList = std::vector<Payload>;
 
 public: // methods
-    Connection();
+    Connection() = default;
 
     virtual ~Connection() = default;
 
@@ -82,7 +81,7 @@ private:  // methods
     virtual const eckit::net::TCPSocket& dataSocket() const = 0;
 
 protected:  // members
-    bool single_;
+    bool single_ {false};
 
 private:  // members
     mutable std::mutex controlMutex_;

--- a/src/fdb5/remote/Messages.cc
+++ b/src/fdb5/remote/Messages.cc
@@ -15,7 +15,24 @@
 
 #include "fdb5/remote/Messages.h"
 
+#include <cstddef>
+#include <ostream>
+
 namespace fdb5::remote {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+Payload::Payload(const BufferStream& buffer) : length {buffer.length()}, data {buffer.data()} { }
+
+Payload::Payload(const std::size_t length, const void* data) : length {length}, data {data} { }
+
+bool Payload::empty() const {
+    return data == nullptr && length == 0;
+}
+
+bool Payload::consistent() const {
+    return ((length == 0) ^ (data == nullptr)) == 0;
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -46,6 +63,7 @@ std::ostream& operator<<(std::ostream& s, const Message& m) {
         case Message::Store: s << "Store"; break;
         case Message::Axes: s << "Axes"; break;
         case Message::Exists: s << "Exists"; break;
+        case Message::Overlay: s << "Overlay"; break;
 
     // Responses
         case Message::Received: s << "Received"; break;

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -198,7 +198,8 @@ void ClientConnection::dataWrite(DataWriteRequest& request) const {
 
 void ClientConnection::dataWrite(Client& client, remote::Message msg, uint32_t requestID, PayloadList payloads) {
 
-    static size_t maxQueueLength = eckit::Resource<size_t>("fdbDataWriteQueueLength;$FDB_DATA_WRITE_QUEUE_LENGTH", 320);
+    static const size_t maxQueueLength =
+        eckit::Resource<size_t>("fdbDataWriteQueueLength;$FDB_DATA_WRITE_QUEUE_LENGTH", defaultDataWriteQueueLength);
 
     {
         // retrieve or add client to the list

--- a/src/fdb5/remote/client/ClientConnection.h
+++ b/src/fdb5/remote/client/ClientConnection.h
@@ -34,6 +34,8 @@ class DataWriteRequest;
 
 class ClientConnection : protected Connection {
 
+    static constexpr size_t defaultDataWriteQueueLength = 320;
+
 public: // methods
     ~ClientConnection() override;
 

--- a/src/fdb5/remote/client/RemoteCatalogue.h
+++ b/src/fdb5/remote/client/RemoteCatalogue.h
@@ -36,7 +36,9 @@ public:  // methods
     // From CatalogueWriter
     const Index& currentIndex() override;
     void archive(const Key& idxKey, const Key& datumKey, std::shared_ptr<const FieldLocation> fieldLocation) override;
-    void overlayDB(const Catalogue& otherCatalogue, const std::set<std::string>& variableKeys, bool unmount) override;
+
+    void overlayDB(const Catalogue* srcCatalogue, const eckit::StringSet& variableKeys, bool unmount) override;
+
     void index(const Key& key, const eckit::URI& uri, eckit::Offset offset, eckit::Length length) override;
     void reconsolidate() override;
 

--- a/src/fdb5/remote/client/RemoteStore.h
+++ b/src/fdb5/remote/client/RemoteStore.h
@@ -108,6 +108,9 @@ public: // types
     using StoredMessage = std::pair<Message, eckit::Buffer>;
     using MessageQueue  = eckit::Queue<StoredMessage>;
 
+    static constexpr size_t defaultEncodeBufferSize    = 4096;
+    static constexpr size_t defaultRetrieveQueueLength = 320;
+
     static const char* typeName() { return "remote"; }
 
 public: // methods

--- a/src/fdb5/remote/server/CatalogueHandler.h
+++ b/src/fdb5/remote/server/CatalogueHandler.h
@@ -38,10 +38,9 @@ struct CatalogueArchiver {
 
 //----------------------------------------------------------------------------------------------------------------------
 class CatalogueHandler : public ServerConnection {
-public:  // methods
 
+public:  // methods
     CatalogueHandler(eckit::net::TCPSocket& socket, const Config& config);
-    ~CatalogueHandler() override;
 
 private:  // methods
 
@@ -60,6 +59,7 @@ private:  // methods
     void schema(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload);
     void stores(uint32_t clientID, uint32_t requestID);
     void exists(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) const;
+    void overlay(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) const;
 
     void archiveBlob(const uint32_t clientID, const uint32_t requestID, const void* data, size_t length) override;
 

--- a/src/fdb5/remote/server/ServerConnection.cc
+++ b/src/fdb5/remote/server/ServerConnection.cc
@@ -55,9 +55,6 @@ namespace fdb5::remote {
 
 namespace {
 
-constexpr const auto defaultRetrieveQueueSize = 10000;
-constexpr const auto defaultArchiveQueueSize = 320;
-
 std::vector<int> intersection(const eckit::LocalConfiguration& c1, const eckit::LocalConfiguration& c2, const std::string& field){
 
     std::vector<int> v1 = c1.getIntVector(field);
@@ -80,8 +77,8 @@ std::vector<int> intersection(const eckit::LocalConfiguration& c1, const eckit::
 ServerConnection::ServerConnection(eckit::net::TCPSocket& socket, const Config& config)
     : config_(config),
       dataListenHostname_(config.getString("dataListenHostname", "")),
-      readLocationQueue_(eckit::Resource<size_t>("fdbRetrieveQueueSize", defaultRetrieveQueueSize)),
-      archiveQueue_(eckit::Resource<size_t>("fdbServerMaxQueueSize", defaultArchiveQueueSize)),
+      readLocationQueue_(eckit::Resource<size_t>("fdbRetrieveQueueSize", defaultRetrieveQueueLength)),
+      archiveQueue_(eckit::Resource<size_t>("fdbServerMaxQueueSize", defaultArchiveQueueLength)),
       controlSocket_(socket) {
 
     LOG_DEBUG_LIB(LibFdb5) << "ServerConnection::ServerConnection initialized" << std::endl;

--- a/src/fdb5/remote/server/ServerConnection.h
+++ b/src/fdb5/remote/server/ServerConnection.h
@@ -84,7 +84,14 @@ struct ArchiveElem {
         clientID_(clientID), requestID_(requestID), payload_(std::move(payload)), multiblob_(multiblob) {}
 };
 
+//----------------------------------------------------------------------------------------------------------------------
+
 class ServerConnection : public Connection, public Handler {
+
+    static constexpr size_t defaultRetrieveQueueLength = 320;
+
+    static constexpr size_t defaultArchiveQueueLength = 10000;
+
 public:  // methods
     ServerConnection(eckit::net::TCPSocket& socket, const Config& config);
     ~ServerConnection() override;

--- a/src/fdb5/remote/server/StoreHandler.cc
+++ b/src/fdb5/remote/server/StoreHandler.cc
@@ -290,11 +290,11 @@ void StoreHandler::exists(const uint32_t clientID, const uint32_t requestID, con
         exists = StoreFactory::instance().build(dbKey, config_)->exists();
     }
 
-    eckit::Buffer       existBuf(5);
-    eckit::MemoryStream stream(existBuf);
-    stream << exists;
+    BufferStream existsBuf(5);
+    existsBuf << exists;
 
-    write(Message::Received, true, clientID, requestID, existBuf.data(), stream.position());
+    // reply to the client
+    write(Message::Received, true, clientID, requestID, {existsBuf.payload()});
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/toc/TocCatalogue.cc
+++ b/src/fdb5/toc/TocCatalogue.cc
@@ -14,10 +14,11 @@
 #include "fdb5/rules/Rule.h"
 #include "fdb5/toc/RootManager.h"
 #include "fdb5/toc/TocCatalogue.h"
+#include "fdb5/toc/TocEngine.h"
+#include "fdb5/toc/TocMoveVisitor.h"
 #include "fdb5/toc/TocPurgeVisitor.h"
 #include "fdb5/toc/TocStats.h"
 #include "fdb5/toc/TocWipeVisitor.h"
-#include "fdb5/toc/TocMoveVisitor.h"
 
 using namespace eckit;
 

--- a/src/fdb5/toc/TocCatalogue.h
+++ b/src/fdb5/toc/TocCatalogue.h
@@ -21,7 +21,6 @@
 #include "fdb5/rules/Schema.h"
 #include "fdb5/toc/FileSpace.h"
 #include "fdb5/toc/TocHandler.h"
-#include "fdb5/toc/TocEngine.h"
 
 namespace fdb5 {
 
@@ -45,6 +44,8 @@ public: // methods
 
     bool enabled(const ControlIdentifier& controlIdentifier) const override;
 
+    bool exists() const override;
+
 public: // constants
     static const std::string DUMP_PARAM_WALKSUBTOC;
 
@@ -60,7 +61,7 @@ protected: // methods
                                    std::vector<Key>* remapKeys = nullptr) const;
 
     void checkUID() const override;
-    bool exists() const override;
+
     void dump(std::ostream& out, bool simple, const eckit::Configuration& conf) const override;
     std::vector<eckit::PathName> metadataPaths() const override;
     const Schema& schema() const override;

--- a/src/fdb5/toc/TocCatalogueWriter.cc
+++ b/src/fdb5/toc/TocCatalogueWriter.cc
@@ -8,21 +8,20 @@
  * does it submit to any jurisdiction.
  */
 
-#include "fdb5/fdb5_config.h"
-
-#include "eckit/config/Resource.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/filesystem/PathName.h"
 #include "eckit/log/Log.h"
-#include "eckit/log/Bytes.h"
-#include "eckit/io/EmptyHandle.h"
+#include "eckit/types/Types.h"
 
-#include "fdb5/database/EntryVisitMechanism.h"
-#include "fdb5/io/FDBFileHandle.h"
 #include "fdb5/LibFdb5.h"
+#include "fdb5/database/EntryVisitMechanism.h"
+#include "fdb5/io/LustreSettings.h"
+#include "fdb5/toc/RootManager.h"
+#include "fdb5/toc/TocCatalogue.h"
 #include "fdb5/toc/TocCatalogueWriter.h"
 #include "fdb5/toc/TocFieldLocation.h"
 #include "fdb5/toc/TocIndex.h"
-#include "fdb5/toc/RootManager.h"
-#include "fdb5/io/LustreSettings.h"
+#include <sstream>
 
 using namespace eckit;
 
@@ -240,34 +239,49 @@ const TocSerialisationVersion& TocCatalogueWriter::serialisationVersion() const 
     return TocHandler::serialisationVersion();
 }
 
-void TocCatalogueWriter::overlayDB(const Catalogue& otherCat, const std::set<std::string>& variableKeys, bool unmount) {
+void TocCatalogueWriter::overlayDB(const Catalogue* srcCatalogue, const eckit::StringSet& variableKeys, bool unmount) {
 
-    const TocCatalogue& otherCatalogue = dynamic_cast<const TocCatalogue&>(otherCat);
-    const Key& otherKey(otherCatalogue.key());
+    const auto* source = dynamic_cast<const TocCatalogue*>(srcCatalogue);
 
-    if (otherKey.size() != TocCatalogue::dbKey_.size()) {
-        std::stringstream ss;
-        ss << "Keys insufficiently matching for mount: " << TocCatalogue::dbKey_ << " : " << otherKey;
-        throw UserError(ss.str(), Here());
+    if (!source) { throw eckit::UserError("Cannot overlay toc DB with a non-toc source DB!", Here()); }
+
+    if (!source->exists()) {
+        std::ostringstream oss;
+        oss << "Source database is not found: " << *source << std::endl;
+        throw eckit::UserError(oss.str(), Here());
     }
 
-    // Build the difference map from the old to the new key
+    if (source->uri() == uri()) {
+        std::ostringstream oss;
+        oss << "Source and target cannot be same! " << source->uri() << " : " << uri();
+        throw eckit::UserError(oss.str(), Here());
+    }
 
-    for (const auto& kv : TocCatalogue::dbKey_) {
+    const auto& srcKey = source->key();
 
-        auto it = otherKey.find(kv.first);
-        if (it == otherKey.end()) {
-            std::stringstream ss;
-            ss << "Keys insufficiently matching for mount: " << TocCatalogue::dbKey_ << " : " << otherKey;
-            throw UserError(ss.str(), Here());
+    // check keywords are matching
+    if (srcKey.keys() != dbKey_.keys()) {
+        std::ostringstream oss;
+        oss << "Keys are not matching! " << srcKey << " : " << dbKey_ << std::endl;
+        throw eckit::UserError(oss.str(), Here());
+    }
+
+    // check values are as expected
+    for (const auto& [keyword, value] : dbKey_) {
+
+        const auto isDifferent = srcKey.find(keyword)->second != value;
+        const auto isVariable  = variableKeys.find(keyword) != variableKeys.end();
+
+        if (isDifferent && !isVariable) {
+            std::ostringstream oss;
+            oss << "Keyword [" << keyword << "] must not differ between DBs: " << srcKey << " : " << dbKey_;
+            throw eckit::UserError(oss.str(), Here());
         }
 
-        if (kv.second != it->second) {
-            if (variableKeys.find(kv.first) == variableKeys.end()) {
-                std::stringstream ss;
-                ss << "Key " << kv.first << " not allowed to differ between DBs: " << TocCatalogue::dbKey_ << " : " << otherKey;
-                throw UserError(ss.str(), Here());
-            }
+        if (isVariable && !isDifferent) {
+            std::ostringstream oss;
+            oss << "Variable Keyword [" << keyword << "] must differ between DBs: " << srcKey << " : " << dbKey_;
+            throw eckit::UserError(oss.str(), Here());
         }
     }
 
@@ -276,19 +290,19 @@ void TocCatalogueWriter::overlayDB(const Catalogue& otherCat, const std::set<std
 
         // First sanity check that we are already mounted
 
-        std::set<std::string> subtocs;
+        eckit::StringSet subtocs;
         loadIndexes(false, &subtocs);
 
-        eckit::PathName stPath(otherCatalogue.tocPath());
+        eckit::PathName stPath(source->tocPath());
         if (subtocs.find(stPath) == subtocs.end()) {
             std::stringstream ss;
-            ss << "Cannot unmount DB: " << otherCatalogue << ". Not currently mounted";
-            throw UserError(ss.str(), Here());
+            ss << "Cannot unmount source DB [" << source << "] that is already unmounted!";
+            throw eckit::UserError(ss.str(), Here());
         }
 
-        writeSubTocMaskRecord(otherCatalogue);
+        writeSubTocMaskRecord(*source);
     } else {
-        writeSubTocRecord(otherCatalogue);
+        writeSubTocRecord(*source);
     }
 }
 
@@ -423,4 +437,4 @@ static CatalogueWriterBuilder<TocCatalogueWriter> builder("toc");
 
 //----------------------------------------------------------------------------------------------------------------------
 
-} // namespace fdb5
+}  // namespace fdb5

--- a/src/fdb5/toc/TocCatalogueWriter.h
+++ b/src/fdb5/toc/TocCatalogueWriter.h
@@ -19,8 +19,6 @@
 #include "eckit/os/AutoUmask.h"
 
 #include "fdb5/database/Index.h"
-#include "fdb5/toc/TocRecord.h"
-
 #include "fdb5/toc/TocCatalogue.h"
 #include "fdb5/toc/TocSerialisationVersion.h"
 
@@ -50,7 +48,7 @@ public: // methods
     /// Mount an existing TocCatalogue, which has a different metadata key (within
     /// constraints) to allow on-line rebadging of data
     /// variableKeys: The keys that are allowed to differ between the two DBs
-    void overlayDB(const Catalogue& otherCatalogue, const std::set<std::string>& variableKeys, bool unmount) override;
+    void overlayDB(const Catalogue* srcCatalogue, const eckit::StringSet& variableKeys, bool unmount) override;
 
     // Hide the contents of the DB!!!
     void hideContents() override;


### PR DESCRIPTION
This implements the remote FDB catalogue overlay functionality.

It uses the local FDB toc catalogue overlay.

It is restricted that overlay happens on the same server.

Also, removed duplicated checks in `fdb-overlay` CLI tool. Now, checks are moved to toc catalogue.