### PR TITLE
Feature/fdb 389 dump tools

### DIFF
--- a/src/fdb5/toc/RootManager.cc
+++ b/src/fdb5/toc/RootManager.cc
@@ -631,9 +631,8 @@ std::vector<PathName> RootManager::visitableRoots(const std::set<Key>& keys) {
 
     eckit::StringSet roots;
 
-    std::vector<std::string> keystrings;
-    std::transform(keys.begin(), keys.end(), std::back_inserter(keystrings),
-                   [](const Key& k) { return k.valuesToString(); });
+    std::set<std::string> keystrings;
+    for (const auto& key : keys) { keystrings.insert(key.valuesToString()); }
 
     LOG_DEBUG_LIB(LibFdb5) << "RootManager::visitableRoots() trying to match keys " << keystrings << std::endl;
 

--- a/src/fdb5/toc/RootManager.cc
+++ b/src/fdb5/toc/RootManager.cc
@@ -11,16 +11,17 @@
 #include "RootManager.h"
 
 #include <fstream>
-#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
 
-#include "eckit/types/Types.h"
 #include "eckit/config/Resource.h"
-#include "eckit/utils/Tokenizer.h"
-#include "eckit/utils/StringTools.h"
-#include "eckit/utils/Translator.h"
-#include "eckit/thread/Mutex.h"
-#include "eckit/thread/AutoLock.h"
 #include "eckit/filesystem/LocalPathName.h"
+#include "eckit/thread/AutoLock.h"
+#include "eckit/thread/Mutex.h"
+#include "eckit/types/Types.h"
+#include "eckit/utils/Tokenizer.h"
+#include "eckit/utils/Translator.h"
 
 #include "metkit/mars/MarsRequest.h"
 

--- a/src/fdb5/toc/TocCatalogueWriter.cc
+++ b/src/fdb5/toc/TocCatalogueWriter.cc
@@ -66,7 +66,7 @@ bool TocCatalogueWriter::selectIndex(const Key& idxKey) {
             fdb5LustreapiFileCreate(indexPath, stripeIndexLustreSettings());
         }
 
-        indexes_[idxKey] = Index(new TocIndex(idxKey, *this, indexPath, 0, TocIndex::WRITE));
+        indexes_[idxKey] = Index(new TocIndex(idxKey, indexPath, 0, TocIndex::WRITE));
     }
 
     current_ = indexes_[idxKey];
@@ -88,7 +88,7 @@ bool TocCatalogueWriter::selectIndex(const Key& idxKey) {
                 fdb5LustreapiFileCreate(indexPath, stripeIndexLustreSettings());
             }
 
-            fullIndexes_[idxKey] = Index(new TocIndex(idxKey, *this, indexPath, 0, TocIndex::WRITE));
+            fullIndexes_[idxKey] = Index(new TocIndex(idxKey, indexPath, 0, TocIndex::WRITE));
         }
 
         currentFull_ = fullIndexes_[idxKey];

--- a/src/fdb5/toc/TocEngine.h
+++ b/src/fdb5/toc/TocEngine.h
@@ -39,7 +39,7 @@ private:  // methods
     std::vector<eckit::URI> databases(const metkit::mars::MarsRequest& rq, const std::vector<eckit::PathName>& dirs,
                                       const Config& config) const;
 
-    void scan_dbs(const std::string& path, std::list<std::string>& dbs) const;
+    void scan_dbs(const std::string& path, std::list<std::string>& dbs, bool lowercase = false) const;
 
 protected: // methods
 

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -1340,7 +1340,7 @@ std::vector<Index> TocHandler::loadIndexes(const Catalogue& catalogue, bool sort
                     s >> offset;
                     s >> type;
                     LOG_DEBUG(debug, LibFdb5) << "TocRecord TOC_INDEX " << path << " - " << offset << std::endl;
-                    tocindexes[entry.seqNo] = new TocIndex(s, catalogue, entry.datap->header_.serialisationVersion_,
+                    tocindexes[entry.seqNo] = new TocIndex(s, entry.datap->header_.serialisationVersion_,
                                                            entry.tocDirectoryName,
                                                            entry.tocDirectoryName / path,
                                                            offset, preloadBTree_);
@@ -1443,7 +1443,7 @@ void TocHandler::dump(std::ostream& out, bool simple, bool walkSubTocs) const {
                 s >> type;
                 out << "  Path: " << path << ", offset: " << offset << ", type: " << type;
                 if(!simple) { out << std::endl; }
-                Index index(new TocIndex(s, *(dynamic_cast<const TocCatalogue*>(this)), r->header_.serialisationVersion_,
+                Index index(new TocIndex(s, r->header_.serialisationVersion_,
                                          currentDirectory(), currentDirectory() / path, offset));
                 index.dump(out, "  ", simple);
                 break;
@@ -1500,7 +1500,7 @@ void TocHandler::dumpIndexFile(std::ostream& out, const eckit::PathName& indexFi
                 if ((currentDirectory() / path).sameAs(eckit::LocalPathName{indexFile})) {
                     r->dump(out, true);
                     out << std::endl << "  Path: " << path << ", offset: " << offset << ", type: " << type;
-                    Index index(new TocIndex(s, *(dynamic_cast<const TocCatalogue*>(this)), r->header_.serialisationVersion_,
+                    Index index(new TocIndex(s, r->header_.serialisationVersion_,
                                              currentDirectory(), currentDirectory() / path, offset));
                     index.dump(out, "  ", false, true);
                 }
@@ -1609,7 +1609,7 @@ void TocHandler::enumerateMasked(const Catalogue& catalogue, std::set<std::pair<
             std::pair<eckit::LocalPathName, size_t> key(absPath.baseName(), offset);
             if (maskedEntries_.find(key) != maskedEntries_.end()) {
                 if (absPath.exists()) {
-                    Index index(new TocIndex(s, *(dynamic_cast<const TocCatalogue*>(this)), r->header_.serialisationVersion_, directory_, absPath, offset));
+                    Index index(new TocIndex(s, r->header_.serialisationVersion_, directory_, absPath, offset));
                     for (const auto& dataURI : index.dataURIs()) data.insert(dataURI);
                 }
             }

--- a/src/fdb5/toc/TocIndex.cc
+++ b/src/fdb5/toc/TocIndex.cc
@@ -46,7 +46,6 @@ public:
 ///       the members of TocIndex
 
 TocIndex::TocIndex(const Key&             key,
-                   const Catalogue&       catalogue,
                    const eckit::PathName& path,
                    off_t                  offset,
                    Mode                   mode,
@@ -60,7 +59,6 @@ TocIndex::TocIndex(const Key&             key,
       preloadBTree_(false) { }
 
 TocIndex::TocIndex(eckit::Stream&         s,
-                   const Catalogue&       catalogue,
                    const int              version,
                    const eckit::PathName& directory,
                    const eckit::PathName& path,

--- a/src/fdb5/toc/TocIndex.h
+++ b/src/fdb5/toc/TocIndex.h
@@ -62,14 +62,12 @@ public: // types
 public: // methods
 
     TocIndex(const Key& key,
-             const Catalogue& catalogue,
              const eckit::PathName &path,
              off_t offset,
              Mode mode,
              const std::string& type = defaulType());
 
     TocIndex(eckit::Stream &,
-             const Catalogue& catalogue,
              const int version,
              const eckit::PathName &directory,
              const eckit::PathName &path,

--- a/src/fdb5/tools/fdb-read.cc
+++ b/src/fdb5/tools/fdb-read.cc
@@ -98,7 +98,7 @@ void FDBRead::execute(const eckit::option::CmdArgs &args) {
 
     std::unique_ptr<eckit::DataHandle> dh(handles.dataHandle());
 
-    dh->copyTo(out);
+    dh->saveInto(out);
 }
 
 


### PR DESCRIPTION
fdb-dump-toc and fdb-dump-index where creating a TocHandler and passing to TocIndex ctor after a cast to TocCatalogue
The cast was failing since the object where created as TocHandler (superclass of TocCatalogue)

catalogue is no longer used in TocIndex, thus I've removed the offending cast


