### PR TITLE
Remove disable/disabled from FDB api

### DIFF
--- a/src/fdb5/api/DistFDB.h
+++ b/src/fdb5/api/DistFDB.h
@@ -24,6 +24,8 @@
 
 #include "eckit/utils/RendezvousHash.h"
 
+#include <tuple>
+
 
 namespace fdb5 {
 
@@ -79,7 +81,8 @@ private:
 
     eckit::RendezvousHash hash_;
 
-    std::vector<FDB> lanes_;
+    /// Stores FDB and its enabled status
+    std::vector<std::tuple<FDB, bool>> lanes_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/api/FDB.cc
+++ b/src/fdb5/api/FDB.cc
@@ -328,14 +328,6 @@ bool FDB::dirty() const {
     return dirty_;
 }
 
-void FDB::disable() {
-    internal_->disable();
-}
-
-bool FDB::disabled() const {
-    return internal_->disabled();
-}
-
 bool FDB::enabled(const ControlIdentifier& controlIdentifier) const {
     return internal_->enabled(controlIdentifier);
 }

--- a/src/fdb5/api/FDB.h
+++ b/src/fdb5/api/FDB.h
@@ -141,9 +141,6 @@ public:  // methods
     const std::string& name() const;
     const Config& config() const;
 
-    void disable();
-    bool disabled() const;
-
 private:  // methods
 
     void print(std::ostream&) const;

--- a/src/fdb5/api/FDBFactory.cc
+++ b/src/fdb5/api/FDBFactory.cc
@@ -30,7 +30,7 @@ namespace fdb5 {
 //----------------------------------------------------------------------------------------------------------------------
 
 
-FDBBase::FDBBase(const Config& config, const std::string& name) : name_(name), config_(config), disabled_(false) {
+FDBBase::FDBBase(const Config& config, const std::string& name) : name_(name), config_(config) {
 
     bool writable  = config.getBool("writable", true);
     bool visitable = config.getBool("visitable", true);
@@ -74,15 +74,6 @@ const Config& FDBBase::config() const {
 
 bool FDBBase::enabled(const ControlIdentifier& controlIdentifier) const {
     return controlIdentifiers_.enabled(controlIdentifier);
-}
-
-void FDBBase::disable() {
-    eckit::Log::warning() << "Disabling FDB " << *this << std::endl;
-    disabled_ = true;
-}
-
-bool FDBBase::disabled() {
-    return disabled_;
 }
 
 FDBFactory& FDBFactory::instance() {

--- a/src/fdb5/api/FDBFactory.h
+++ b/src/fdb5/api/FDBFactory.h
@@ -108,9 +108,6 @@ public:  // methods
 
     const Config& config() const;
 
-    void disable();
-    bool disabled();
-
     bool enabled(const ControlIdentifier& controlIdentifier) const;
 
 private:  // methods
@@ -129,8 +126,6 @@ protected:  // members
     Config config_;
 
     ControlIdentifiers controlIdentifiers_;
-
-    bool disabled_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/types/TypeMonthOfDate.cc
+++ b/src/fdb5/types/TypeMonthOfDate.cc
@@ -40,7 +40,7 @@ std::string TypeMonthOfDate::toKey(const std::string& value) const {
 }
 
 void TypeMonthOfDate::getValues(const metkit::mars::MarsRequest& request, const std::string& keyword,
-                          eckit::StringList& values, const Notifier&, const CatalogueReader*) const {
+                                eckit::StringList& values, const Notifier&, const CatalogueReader*) const {
     std::vector<eckit::Date> dates;
 
     request.getValues(keyword, dates, true);


### PR DESCRIPTION
FDB api allowed to disable() / check disabled() state of FDB, this flah however was only used in DistFDB to disable 'lanes' that encountered errors on archive. Methods and field have bveen removed since there is no working functionality from the APIs user point of view.