### PR TITLE
FDB-417: Lazily instantiate FDB objects

### DIFF
--- a/src/fdb5/api/SelectFDB.h
+++ b/src/fdb5/api/SelectFDB.h
@@ -16,10 +16,10 @@
 /// @author Simon Smart
 /// @date   Mar 2018
 
-#ifndef fdb5_api_SelectFDB_H
-#define fdb5_api_SelectFDB_H
+#pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -37,6 +37,15 @@ class SelectFDB : public FDBBase {
 private:  // types
 
     using SelectMap = std::map<std::string, eckit::Regex>;
+
+    struct FDBLane {
+        SelectMap select;
+        Config config;
+        std::optional<FDB> fdb;
+
+        FDB& get();
+        void flush();
+    };
 
 public:  // methods
 
@@ -83,11 +92,10 @@ private:  // methods
 
 private:  // members
 
-    std::vector<std::pair<SelectMap, FDB>> subFdbs_;
+    std::vector<FDBLane> subFdbs_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace fdb5
 
-#endif  // fdb5_api_SelectFDB_H

--- a/src/fdb5/api/SelectFDB.h
+++ b/src/fdb5/api/SelectFDB.h
@@ -38,11 +38,14 @@ private:  // types
 
     using SelectMap = std::map<std::string, eckit::Regex>;
 
-    struct FDBLane {
-        SelectMap select;
-        Config config;
-        std::optional<FDB> fdb;
+    class FDBLane {
+        SelectMap select_;
+        Config config_;
+        std::optional<FDB> fdb_;
 
+    public:
+        FDBLane(const eckit::LocalConfiguration& config);
+        const SelectMap& select() { return select_; }
         FDB& get();
         void flush();
     };

--- a/src/fdb5/api/SelectFDB.h
+++ b/src/fdb5/api/SelectFDB.h
@@ -44,6 +44,7 @@ private:  // types
         std::optional<FDB> fdb_;
 
     public:
+
         FDBLane(const eckit::LocalConfiguration& config);
         const SelectMap& select() { return select_; }
         FDB& get();
@@ -101,4 +102,3 @@ private:  // members
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace fdb5
-

--- a/tests/fdb/api/test_select.cc
+++ b/tests/fdb/api/test_select.cc
@@ -65,7 +65,7 @@ CASE("archives_distributed_according_to_select") {
     // Build FDB from default config
 
     fdb5::FDB fdb(defaultConfig());
-    EXPECT(ApiSpy::knownSpies().size() == 0); // laxy creation
+    EXPECT(ApiSpy::knownSpies().size() == 0);  // lazy creation
 
     // Flush does nothing until dirty
     fdb.flush();
@@ -142,7 +142,6 @@ CASE("archives_distributed_according_to_select") {
         EXPECT(spy->counts().stats == 0);
         EXPECT(spy->counts().control == 0);
     }
-
 }
 
 

--- a/tests/fdb/api/test_select.cc
+++ b/tests/fdb/api/test_select.cc
@@ -131,7 +131,7 @@ CASE("archives_distributed_according_to_select") {
     // And unused functions
 
     ApiSpy* spies[] = {&spy_od, &spy_rd2};
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 2; i++) {
         ApiSpy* spy = spies[i];
         EXPECT(spy->counts().inspect == 0);
         EXPECT(spy->counts().list == 0);


### PR DESCRIPTION
By lazily constructing FDB objects, we avoid FDB Remote instances connecting to their counterparts even if those lanes are not going to be used.

This does have two negative consequences:

1. By delaying when the connections happy, we may increase end-to-end times
2. We defer when the config for the sub-FDBs are read, which means we can end up with runtime errors later in the process

Comments welcome.