### PR TITLE
Fix/fdb 419

### DIFF
--- a/src/fdb5/api/RemoteFDB.cc
+++ b/src/fdb5/api/RemoteFDB.cc
@@ -208,6 +208,9 @@ auto RemoteFDB::forwardApiCall(const HelperClass& helper, const FDBToolRequest& 
     using IteratorType  = APIIterator<ValueType>;
     using AsyncIterator = APIAsyncIterator<ValueType>;
 
+    // Reconnect if necessary
+    refreshConnection();
+
     // Ensure we have an entry in the message queue before we trigger anything that
     // will result in return messages
 

--- a/src/fdb5/remote/Connection.h
+++ b/src/fdb5/remote/Connection.h
@@ -74,6 +74,8 @@ public:  // methods
 
     void teardown();
 
+    bool valid() const { return isValid_; }
+
 private:  // methods
 
     eckit::Buffer read(bool control, MessageHeader& hdr) const;
@@ -97,6 +99,9 @@ private:  // members
     mutable std::mutex dataMutex_;
     mutable std::mutex readControlMutex_;
     mutable std::mutex readDataMutex_;
+
+    // Used to flag that a TCPException has been thrown
+    mutable std::atomic<bool> isValid_{true};
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/client/Client.cc
+++ b/src/fdb5/remote/client/Client.cc
@@ -41,18 +41,18 @@ Client::Client(const eckit::net::Endpoint& endpoint, const std::string& defaultE
     connection_(ClientConnectionRouter::instance().connection(endpoint, defaultEndpoint)) {
 
     setClientID();
-    connection_.add(*this);
+    connection_->add(*this);
 }
 
 Client::Client(const std::vector<std::pair<eckit::net::Endpoint, std::string>>& endpoints) :
     connection_(ClientConnectionRouter::instance().connection(endpoints)) {
 
     setClientID();
-    connection_.add(*this);
+    connection_->add(*this);
 }
 
 Client::~Client() {
-    connection_.remove(id_);
+    connection_->remove(id_);
 }
 
 void Client::controlWriteCheckResponse(const Message msg, const uint32_t requestID, const bool dataListener,
@@ -67,7 +67,7 @@ void Client::controlWriteCheckResponse(const Message msg, const uint32_t request
         payloads.emplace_back(payloadLength, payload);
     }
 
-    auto f = connection_.controlWrite(*this, msg, requestID, dataListener, payloads);
+    auto f = connection_->controlWrite(*this, msg, requestID, dataListener, payloads);
     f.wait();
     ASSERT(f.get().size() == 0);
 }
@@ -84,13 +84,13 @@ eckit::Buffer Client::controlWriteReadResponse(const Message msg, const uint32_t
         payloads.emplace_back(payloadLength, payload);
     }
 
-    auto f = connection_.controlWrite(*this, msg, requestID, false, payloads);
+    auto f = connection_->controlWrite(*this, msg, requestID, false, payloads);
     f.wait();
     return eckit::Buffer{f.get()};
 }
 
 void Client::dataWrite(Message msg, uint32_t requestID, PayloadList payloads) {
-    connection_.dataWrite(*this, msg, requestID, std::move(payloads));
+    connection_->dataWrite(*this, msg, requestID, std::move(payloads));
 }
 
 }  // namespace fdb5::remote

--- a/src/fdb5/remote/client/Client.h
+++ b/src/fdb5/remote/client/Client.h
@@ -76,6 +76,9 @@ public:  // methods
     virtual bool handle(Message message, uint32_t requestID, eckit::Buffer&& payload) = 0;
     virtual void closeConnection() {}
 
+    // Create a new connection if the current one is invalid
+    void refreshConnection();
+
 protected:
 
     std::shared_ptr<ClientConnection> connection_;

--- a/src/fdb5/remote/client/Client.h
+++ b/src/fdb5/remote/client/Client.h
@@ -56,11 +56,11 @@ public:  // methods
 
     uint32_t id() const { return id_; }
 
-    const eckit::net::Endpoint& controlEndpoint() const { return connection_.controlEndpoint(); }
+    const eckit::net::Endpoint& controlEndpoint() const { return connection_->controlEndpoint(); }
 
-    const std::string& defaultEndpoint() const { return connection_.defaultEndpoint(); }
+    const std::string& defaultEndpoint() const { return connection_->defaultEndpoint(); }
 
-    uint32_t generateRequestID() const { return connection_.generateRequestID(); }
+    uint32_t generateRequestID() const { return connection_->generateRequestID(); }
 
     // blocking requests
     void controlWriteCheckResponse(Message msg, uint32_t requestID, bool dataListener, const void* payload = nullptr,
@@ -78,7 +78,7 @@ public:  // methods
 
 protected:
 
-    ClientConnection& connection_;
+    std::shared_ptr<ClientConnection> connection_;
 
 private:
 

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -67,7 +67,6 @@ void ClientConnection::add(Client& client) {
 }
 
 bool ClientConnection::remove(uint32_t clientID) {
-
     std::lock_guard lock(clientsMutex_);
 
     if (clientID > 0) {
@@ -83,6 +82,7 @@ bool ClientConnection::remove(uint32_t clientID) {
 
     if (clients_.empty()) {
         teardown();
+        ClientConnectionRouter::instance().deregister(*this);
     }
 
     return clients_.empty();

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -3,6 +3,7 @@
 #include "fdb5/LibFdb5.h"
 #include "fdb5/remote/Connection.h"
 #include "fdb5/remote/Messages.h"
+#include "fdb5/remote/client/Client.h"
 #include "fdb5/remote/client/ClientConnectionRouter.h"
 
 #include "eckit/config/LocalConfiguration.h"

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -74,7 +74,7 @@ bool ClientConnection::remove(uint32_t clientID) {
         auto it = clients_.find(clientID);
 
         if (it != clients_.end()) {
-            Connection::write(Message::Stop, true, clientID, 0);
+            if (valid()) Connection::write(Message::Stop, true, clientID, 0);
 
             clients_.erase(it);
         }
@@ -94,6 +94,12 @@ ClientConnection::~ClientConnection() {
     }
 
     disconnect();
+
+    /// @todo: Why was this not never joined in the disconnect() method?!
+    if (listeningDataThread_.joinable()) {
+        listeningDataThread_.join();
+    }
+
 }
 
 uint32_t ClientConnection::generateRequestID() {

--- a/src/fdb5/remote/client/ClientConnection.h
+++ b/src/fdb5/remote/client/ClientConnection.h
@@ -37,6 +37,7 @@ class ClientConnection : protected Connection {
 public:  // methods
 
     ~ClientConnection() override;
+    ClientConnection(const eckit::net::Endpoint& controlEndpoint, const std::string& defaultEndpoint);
 
     std::future<eckit::Buffer> controlWrite(const Client& client, Message msg, uint32_t requestID,
                                             bool /*dataListener*/, PayloadList payload = {}) const;
@@ -54,10 +55,7 @@ public:  // methods
     const std::string& defaultEndpoint() const { return defaultEndpoint_; }
 
 private:  // methods
-
     friend class ClientConnectionRouter;
-
-    ClientConnection(const eckit::net::Endpoint& controlEndpoint, const std::string& defaultEndpoint);
 
     void dataWrite(DataWriteRequest& request) const;
 

--- a/src/fdb5/remote/client/ClientConnection.h
+++ b/src/fdb5/remote/client/ClientConnection.h
@@ -54,6 +54,8 @@ public:  // methods
     const eckit::net::Endpoint& controlEndpoint() const;
     const std::string& defaultEndpoint() const { return defaultEndpoint_; }
 
+    using Connection::valid;
+
 private:  // methods
     friend class ClientConnectionRouter;
 

--- a/src/fdb5/remote/client/ClientConnectionRouter.cc
+++ b/src/fdb5/remote/client/ClientConnectionRouter.cc
@@ -29,20 +29,19 @@ namespace fdb5::remote {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-ClientConnection& ClientConnectionRouter::connection(const eckit::net::Endpoint& endpoint,
-                                                     const std::string& defaultEndpoint) {
-
+std::shared_ptr<ClientConnection> ClientConnectionRouter::connection(const eckit::net::Endpoint& endpoint,
+                                                                     const std::string& defaultEndpoint) {
     std::lock_guard<std::mutex> lock(connectionMutex_);
 
     const auto it = connections_.find(endpoint);
     if (it != connections_.end()) {
-        return *(it->second);
+        return (it->second);
     }
     else {
         auto clientConnection = std::make_shared<ClientConnection>(endpoint, defaultEndpoint);
         if (clientConnection->connect()) {
             const auto it = (connections_.emplace(endpoint, clientConnection)).first;
-            return *(it->second);
+            return (it->second);
         }
         else {
             throw ConnectionError(endpoint);
@@ -50,7 +49,7 @@ ClientConnection& ClientConnectionRouter::connection(const eckit::net::Endpoint&
     }
 }
 
-ClientConnection& ClientConnectionRouter::connection(
+std::shared_ptr<ClientConnection> ClientConnectionRouter::connection(
     const std::vector<std::pair<eckit::net::Endpoint, std::string>>& endpoints) {
 
     std::vector<std::pair<eckit::net::Endpoint, std::string>> fullEndpoints{endpoints};
@@ -65,14 +64,13 @@ ClientConnection& ClientConnectionRouter::connection(
         // look for the selected endpoint
         const auto it = connections_.find(endpoint);
         if (it != connections_.end()) {
-            return *(it->second);
+            return (it->second);
         }
         else {  // not yet there, trying to connect
-            auto clientConnection =
-                std::make_shared<ClientConnection>(endpoint, fullEndpoints.at(idx).second);
+            auto clientConnection = std::make_shared<ClientConnection>(endpoint, fullEndpoints.at(idx).second);
             if (clientConnection->connect(true)) {
                 const auto it = (connections_.emplace(endpoint, std::move(clientConnection))).first;
-                return *(it->second);
+                return (it->second);
             }
         }
 

--- a/src/fdb5/remote/client/ClientConnectionRouter.h
+++ b/src/fdb5/remote/client/ClientConnectionRouter.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "fdb5/remote/client/Client.h"
 #include "fdb5/remote/client/ClientConnection.h"
 
 #include <unordered_map>
@@ -24,8 +23,10 @@ public:
 
     static ClientConnectionRouter& instance();
 
-    ClientConnection& connection(const eckit::net::Endpoint& endpoint, const std::string& defaultEndpoint);
-    ClientConnection& connection(const std::vector<std::pair<eckit::net::Endpoint, std::string>>& endpoints);
+    std::shared_ptr<ClientConnection> connection(const eckit::net::Endpoint& endpoint,
+                                                 const std::string& defaultEndpoint);
+    std::shared_ptr<ClientConnection> connection(
+        const std::vector<std::pair<eckit::net::Endpoint, std::string>>& endpoints);
 
     void teardown(std::exception_ptr e);
 

--- a/src/fdb5/remote/client/ClientConnectionRouter.h
+++ b/src/fdb5/remote/client/ClientConnectionRouter.h
@@ -37,7 +37,7 @@ private:
 
     std::mutex connectionMutex_;
     // endpoint -> connection
-    std::unordered_map<eckit::net::Endpoint, std::unique_ptr<ClientConnection>> connections_;
+    std::unordered_map<eckit::net::Endpoint, std::shared_ptr<ClientConnection>> connections_;
 };
 
 }  // namespace fdb5::remote

--- a/src/fdb5/remote/client/ClientConnectionRouter.h
+++ b/src/fdb5/remote/client/ClientConnectionRouter.h
@@ -37,7 +37,9 @@ private:
     ClientConnectionRouter() {}  ///< private constructor only used by singleton
 
     std::mutex connectionMutex_;
-    // endpoint -> connection
+
+    /// @note The ClientConnection is (jointly) owned by the Client objects.
+    /// When the last client is disconnects, the ClientConnection deregisters itself from this map.
     std::unordered_map<eckit::net::Endpoint, std::shared_ptr<ClientConnection>> connections_;
 };
 


### PR DESCRIPTION
- Connection is now a shared ptr owned by the Client objects and the ClientConnectionRouter.
- When the final client using a connection is destroyed, it is evicted from registry.
- The connection is marked as invalid if a TCPException is raised on write/read.
- On an api request, remoteFDB will now check if the connection has been invalidated and if so establish a new one.