### PR TITLE
Tidy up

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ UseColor: On
 Checks: >-
   -*,
   readability-delete-null-pointer,
+  bugprone-use-after-move,
   bugprone-parent-virtual-call,
 
 WarningsAsErrors:             false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >-
   readability-delete-null-pointer,
   bugprone-assignment-in-if-condition,
   bugprone-bool-pointer-implicit-conversion,
+  bugprone-casting-through-void,
   bugprone-parent-virtual-call,
   bugprone-unused-return-value,
   bugprone-use-after-move,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,8 +3,12 @@ UseColor: On
 Checks: >-
   -*,
   readability-delete-null-pointer,
-  bugprone-use-after-move,
+  bugprone-assignment-in-if-condition,
+  bugprone-bool-pointer-implicit-conversion,
   bugprone-parent-virtual-call,
+  bugprone-unused-return-value,
+  bugprone-use-after-move,
+
 
 WarningsAsErrors:             false
 HeaderFileExtensions:         ['', 'h','hh','hpp','hxx']

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# The following refs can be ignored by git blame if 'git blame' is called with
+# --ignore-revs-file .git-blame-ignore-revs
+# Alternatively configure git to always ignore refs stored in this file by
+# calling:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Or extend your git config manually with
+# [blame]
+#    ignoreRevsFile = .git-blame-ignore-revs
+
+# Reformatted codebase with clang-format
+efb1ad8497bc43a84d7a90fe58b25a242aa13183

--- a/src/fdb5/api/helpers/ListIterator.h
+++ b/src/fdb5/api/helpers/ListIterator.h
@@ -54,17 +54,9 @@ public:
     ListIterator(APIIterator<ListElement>&& iter, bool deduplicate = false) :
         APIIterator<ListElement>(std::move(iter)), seenKeys_({}), deduplicate_(deduplicate) {}
 
-    ListIterator(ListIterator&& iter) :
-        APIIterator<ListElement>(std::move(iter)),
-        seenKeys_(std::move(iter.seenKeys_)),
-        deduplicate_(iter.deduplicate_) {}
+    ListIterator(ListIterator&& iter) = default;
 
-    ListIterator& operator=(ListIterator&& iter) {
-        seenKeys_    = std::move(iter.seenKeys_);
-        deduplicate_ = iter.deduplicate_;
-        APIIterator<ListElement>::operator=(std::move(iter));
-        return *this;
-    }
+    ListIterator& operator=(ListIterator&& iter) = default;
 
     bool next(ListElement& elem);
 

--- a/src/fdb5/database/EntryVisitMechanism.cc
+++ b/src/fdb5/database/EntryVisitMechanism.cc
@@ -45,9 +45,7 @@ bool EntryVisitor::preVisitDatabase(const eckit::URI& /*uri*/, const Schema& /*s
 EntryVisitor::EntryVisitor() : currentCatalogue_(nullptr), currentStore_(nullptr), currentIndex_(nullptr) {}
 
 EntryVisitor::~EntryVisitor() {
-    if (currentStore_) {
-        delete currentStore_;
-    }
+    delete currentStore_;
 }
 
 Store& EntryVisitor::store() const {

--- a/src/fdb5/io/FieldHandle.cc
+++ b/src/fdb5/io/FieldHandle.cc
@@ -111,9 +111,7 @@ FieldHandle::~FieldHandle() {
     if (current_ && currentMemoryHandle_) {
         delete current_;
     }
-    if (buffer_) {
-        delete[] buffer_;
-    }
+    delete[] buffer_;
 }
 
 void FieldHandle::openCurrent() {

--- a/src/fdb5/remote/server/ServerConnection.cc
+++ b/src/fdb5/remote/server/ServerConnection.cc
@@ -354,10 +354,10 @@ size_t ServerConnection::archiveThreadLoop() {
             if (elem.multiblob_) {
                 // Handle MultiBlob
 
-                const char* firstData = static_cast<const char*>(elem.payload_.data());  // For pointer arithmetic
+                const char* firstData = reinterpret_cast<const char*>(elem.payload_.data());  // For pointer arithmetic
                 const char* charData  = firstData;
                 while (size_t(charData - firstData) < elem.payload_.size()) {
-                    const MessageHeader* hdr = static_cast<const MessageHeader*>(static_cast<const void*>(charData));
+                    const MessageHeader* hdr = reinterpret_cast<const MessageHeader*>(charData);
                     ASSERT(hdr->message == Message::Blob);
                     ASSERT(hdr->clientID() == elem.clientID_);
                     ASSERT(hdr->requestID == elem.requestID_);
@@ -366,7 +366,7 @@ size_t ServerConnection::archiveThreadLoop() {
                     const void* payloadData = charData;
                     charData += hdr->payloadSize;
 
-                    const auto* e = static_cast<const MessageHeader::MarkerType*>(static_cast<const void*>(charData));
+                    const auto* e = reinterpret_cast<const MessageHeader::MarkerType*>(charData);
                     ASSERT(*e == MessageHeader::EndMarker);
                     charData += MessageHeader::markerBytes;
 


### PR DESCRIPTION
This PR enables a few more tidy checks and addresses them. Additionally it adds a way for git blame to ignore changed from our big reformatting.

[Removed unneeded if](https://github.com/ecmwf/fdb/commit/faa7ac46519754c01fb32b92ec1acc4b13be9b85) 
There is no need to null check a pointer before deleting because 'delete
ptr' where prt = nullptr is a NO-OP.

[Add .git-blame-ignore-revs](https://github.com/ecmwf/fdb/commit/9778fadce2bd58a8e5999af396560c4860b8c0c6) 
'git blame' can be configured to ignore specific commits such as
reformatting the codebase with clang format.

We track the commits we want to be ignored in .git-blame-ignore-revs.

You can use git blame from the cli with:
    git blame --ignore-revs-file .git-blame-ignore-revs <FILE>

Or you configure your git config to always use .git-blame-ignore-revs by
setting:
    git config blame.ignoreRevsFile .git-blame-ignore-revs

Or extending your gitconfig with:

[blame]
    ignoreRevsFile = .git-blame-ignore-revs

Note that .git-blame-ignore-revs is recognized by GitHub.

[Introduce tidy bugprone-use-after-move](https://github.com/ecmwf/fdb/commit/f7b85bea937cf943ebb8a8e6edf6959f3febbfc4) 
Move- constructor / assignment operator can be defaulted in this case.
Silencing the use-after-move warning. In this specific case there was no
bug in the existing code because we moved only the base class part.

[Add aditional tidy checks](https://github.com/ecmwf/fdb/commit/c98cd9eec862bbd4b678917b086330ddd3bb3c95) 
- bugprone-assignment-in-if-condition
- bugprone-bool-pointer-implicit-conversion
- bugprone-unused-return-value,

[Added new tidy-check and fixed warning](https://github.com/ecmwf/fdb/commit/3127dade71aaf5d3375246430571def9b1e169a9) 
Added bugprone-casting-through-void