### PR TITLE
Fix/fdb-443 remote test

### DIFF
--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -7,7 +7,6 @@ if (HAVE_FDB_BUILD_TOOLS) # test scripts use the fdb tools
         add_subdirectory(FDB-243)
         add_subdirectory(FDB-245)
         add_subdirectory(FDB-251)
-        add_subdirectory(FDB-258)
         add_subdirectory(FDB-260)
         add_subdirectory(FDB-264)
         add_subdirectory(FDB-266)
@@ -26,7 +25,11 @@ if (HAVE_FDB_BUILD_TOOLS) # test scripts use the fdb tools
     endif()
 
     add_subdirectory(FDB-241)
-    add_subdirectory(FDB-419)
+
+    if (HAVE_FDB_REMOTE)
+        add_subdirectory(FDB-258)
+        add_subdirectory(FDB-419)
+    endif()
 
 endif()
 

--- a/tests/regressions/FDB-258/CMakeLists.txt
+++ b/tests/regressions/FDB-258/CMakeLists.txt
@@ -1,10 +1,6 @@
-if(HAVE_FDB_REMOTE)
-
 ecbuild_configure_file( FDB-258.sh.in FDB-258.sh @ONLY )
 
 ecbuild_add_test(
     TYPE      SCRIPT
     CONDITION HAVE_EXTRA_TESTS
     COMMAND   FDB-258.sh )
-
-endif()


### PR DESCRIPTION
Dont build remoteFDB tests when the fdb-server has not been built. 