### PR TITLE
Add experimental RTD doc support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,88 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+  commands:
+    - mkdir new_folder && for item in * .*; do [ "$item" != "." ] && [ "$item" != ".." ] && [ "$item" != "new_folder" ] && mv "$item" new_folder/; done
+    - mv new_folder fdb
+    - pip install -r fdb/docs/requirements.txt
+    - pip install cmake
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - git clone --depth 1 --branch v1.1.3 https://gitlab.dkrz.de/k202009/libaec
+    - mkdir libaec-build
+    - mkdir libaec-install
+    - |
+      cd libaec-build
+      cmake ../libaec -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../libaec-install
+      cmake --build . --target install
+    - git clone --depth 1 --branch 3.8.5 https://github.com/ecmwf/ecbuild.git
+    - git clone --depth 1 --branch develop https://github.com/ecmwf/eccodes.git
+    - git clone --depth 1 --branch develop https://github.com/ecmwf/eckit.git
+    - |
+      cat << 'EOF' > CMakeLists.txt
+      cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
+      macro( ecbundle_add_project package_name )
+          #
+          #   add_subdirectory depending on BUILD_\${package_name}
+          #
+          set( BUILD_\${package_name} ON CACHE BOOL "" )
+
+          if( BUILD_\${package_name} )
+              set( dir \${ARGV1} )
+              if( NOT dir )
+                  set( dir \${package_name} )
+              endif()
+              add_subdirectory( \${dir} )
+           endif()
+      endmacro()
+      macro( ecbundle_set key value )
+          set( \${key} \${value} CACHE STRING "" )
+          if( "\${\${key}}" STREQUAL "\${value}" )
+             message("  - \${key} = \${value}" )
+          else()
+             message("  - \${key} = \${\${key}} [default=\${value}]" )
+          endif()
+      endmacro()
+
+      ecbundle_set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
+      ecbundle_set( ENABLE_AEC ON )
+      ecbundle_set( ENABLE_MEMFS ON )
+      ecbundle_set( ENABLE_FORTRAN OFF )
+      ecbundle_set( CMAKE_BUILD_TYPE Release )
+      ecbundle_set( ENABLE_ECKIT_CMD off )
+      ecbundle_set( ENABLE_ECKIT_SQL off )
+      ecbundle_set( ENABLE_PYTHON_API_TESTS ON )
+
+      find_package( ecbuild 3.0 REQUIRED HINTS \${CMAKE_CURRENT_SOURCE_DIR}/ecbuild )
+      project(fdb-bundle VERSION 2025.04)
+
+      ## Initialize
+      include(\${CMAKE_CURRENT_BINARY_DIR}/init.cmake OPTIONAL)
+
+      ## Projects
+
+      ecbundle_add_project( libaec )
+      ecbundle_add_project( eccodes )
+      ecbundle_add_project( eckit )
+      ecbundle_add_project( metkit )
+      ecbundle_add_project( fdb )
+
+      ## Finalize
+      include(\${CMAKE_CURRENT_BINARY_DIR}/final.cmake OPTIONAL)
+
+      ecbuild_install_project(NAME \${PROJECT_NAME})
+      ecbuild_print_summary()
+      EOF
+
+    - git clone --depth 1 --branch develop https://github.com/ecmwf/metkit.git
+    - mkdir build
+    - |
+      cd build
+      cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_FDB_DOCUMENTATION=ON -DCMAKE_PREFIX_PATH=../libaec-install
+      cmake --build . --target fdb-doc
+      cd fdb/docs
+      mv sphinx/* $READTHEDOCS_OUTPUT/html
+

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Doxygen 1.13 REQUIRED)
+find_package(Doxygen 1.9 REQUIRED)
 find_package(Sphinx REQUIRED)
 
 file(GLOB_RECURSE FDB_PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../src/fdb5/api/*.h)


### PR DESCRIPTION
This commit adds RTD doc builds with PR-Preview support. This is still an experiment to see how we want to continue on this.

Notes:
- The build in .readthedocs.yaml is horrific and has to be done because I inist on running the same doc generation locally as in the ci.
- .readthedocs.yaml is very limited in what it allows. Dependencies need to be installable via pip. No system packages can be installed
- My initial attempt to build doc in one of our GH Actions and simply unpack the tarball would work in principle but is complicated to setup so that it offers feature parity to the default RTD/GH integration. When using a prebuild doc tarball you need to wait for the tarball to be created. This means you can no longer use the installed webhook as this will get triggeren on push. You then need to use the RTD rest API to trigger the build once the doc build is finished. This then in turn means you need to call the GH rest api from the RTD build to signal start / success / failure of the build back to GH.