### PR TITLE
FDB-471: Add mutex to TypesRegistry cache

### DIFF
--- a/src/fdb5/types/TypesRegistry.cc
+++ b/src/fdb5/types/TypesRegistry.cc
@@ -85,6 +85,7 @@ void TypesRegistry::addType(const std::string& keyword, const std::string& type)
 }
 
 const Type& TypesRegistry::lookupType(const std::string& keyword) const {
+    std::lock_guard<std::mutex> lock(cacheMutex_);
 
     if (auto iter = cache_.find(keyword); iter != cache_.end()) {
         return *iter->second;

--- a/src/fdb5/types/TypesRegistry.h
+++ b/src/fdb5/types/TypesRegistry.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "eckit/serialisation/Streamable.h"
@@ -76,6 +77,7 @@ private:  // members
     const TypesRegistry* parent_{nullptr};
 
     using TypeMap = std::map<std::string, std::unique_ptr<const Type>>;
+    mutable std::mutex cacheMutex_;
     mutable TypeMap cache_;
 
     // streamable


### PR DESCRIPTION
Adds a mutex to the TypesRegistry's internal cache, as a data race occurs when calling `fdb.list` on a SelectFDB.

**HOWEVER** it is unclear to me why multiple threads would be accessing the same TypesRegistry object in the first place. Someone with understanding should look at this, as it seems likely to me that the `types_` member likely ought to be protected by a mutex also if this object is intentionally used in a multithreaded context.