### PR TITLE
Fix move ctor/oper for FDB

### DIFF
--- a/src/fdb5/api/FDB.cc
+++ b/src/fdb5/api/FDB.cc
@@ -59,6 +59,10 @@ FDB::~FDB() {
     }
 }
 
+FDB::FDB(FDB&&) = default;
+
+FDB& FDB::operator=(FDB&&) = default;
+
 void FDB::archive(eckit::message::Message msg) {
     fdb5::Key key = MessageDecoder::messageToKey(msg);
     archive(key, msg.data(), msg.length());

--- a/src/fdb5/api/FDB.h
+++ b/src/fdb5/api/FDB.h
@@ -74,8 +74,8 @@ public:  // methods
     FDB(const FDB&)            = delete;
     FDB& operator=(const FDB&) = delete;
 
-    FDB(FDB&&)            = default;
-    FDB& operator=(FDB&&) = default;
+    FDB(FDB&&);
+    FDB& operator=(FDB&&);
 
     // -------------- Primary API functions ----------------------------------------------------------------------------
 


### PR DESCRIPTION
FDBs move constructor and move assignment operator where not usable without also including FDBBase.h ad call site.

When declaing move ctor/oper as default in the header both methods are generated inline. FDB has a unique_ptr member to FDBBase and exposes only the FDBBase forward declaration. Construction of a uniquer_ptr from an incomplete type is supported but the type must be complete at the place of destruction.

If calling code includes FDB.h but not the internal FDBBase.h, the inline generated move ctor/oper will not know the complete type of FDBBase and generate a compile error.

The fix is to move the default declaration for both methods to FDB.cpp, here FDBBase.h is included and thus the complete type is visible.

<!-- readthedocs-preview ecmwf-fdb start -->
----
📚 Documentation preview 📚: https://ecmwf-fdb--117.org.readthedocs.build/en/117/

<!-- readthedocs-preview ecmwf-fdb end -->