### PR TITLE
FDB-474: Fix deadock on disconnect()

### DIFF
--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -148,10 +148,10 @@ bool ClientConnection::connect(bool singleAttempt) {
 
 void ClientConnection::disconnect() {
 
-    disconnecting_ = true;
-
-    std::lock_guard lock(clientsMutex_);
-    ASSERT(clients_.empty());
+    {
+        std::lock_guard lock(clientsMutex_);
+        ASSERT(clients_.empty());
+    }
 
     if (connected_) {
         if (dataWriteThread_.joinable()) {
@@ -428,12 +428,10 @@ void ClientConnection::listeningControlThreadLoop() {
 
 void ClientConnection::closeConnection() {
     LOG_DEBUG_LIB(LibFdb5) << "ClientConnection::closeConnection() -- Data thread stopping" << std::endl;
-    if (!disconnecting_) {
-        std::lock_guard lock(clientsMutex_);
-        for (auto& [id, client] : clients_) {
-            client->closeConnection();
-        }
-    };
+    std::lock_guard lock(clientsMutex_);
+    for (auto& [id, client] : clients_) {
+        client->closeConnection();
+    }
 }
 
 void ClientConnection::listeningDataThreadLoop() {

--- a/src/fdb5/remote/client/ClientConnection.h
+++ b/src/fdb5/remote/client/ClientConnection.h
@@ -93,8 +93,6 @@ private:  // members
     eckit::net::TCPClient controlClient_;
     eckit::net::TCPClient dataClient_;
 
-    bool disconnecting_ = false;
-
     std::mutex clientsMutex_;
     std::map<uint32_t, Client*> clients_;
 


### PR DESCRIPTION
The disconnecting_ flag was being used non-atomically, which lead to a race condition on acquiring the clientsMutex_. Since the disconnect() method hangs until all other threads are joined, this led to a deadlock.

I have removed the disconnecting_ flag as I believe it to be redundant, due to the ASSERT(clients_.empty()). I also release the clientsMutex_ lock early in disconnect(), as it does not access the clients_ map after that point. (Additionally, since disconnect() is inside the ClientConnection destructor, something must have gone seriously wrong if clients_ are still mutating at this stage...)

<!-- readthedocs-preview ecmwf-fdb start -->
----
📚 Documentation preview 📚: https://ecmwf-fdb--118.org.readthedocs.build/en/118/

<!-- readthedocs-preview ecmwf-fdb end -->