### PR TITLE
Fix/schema path

### DIFF
--- a/src/fdb5/api/FDB.cc
+++ b/src/fdb5/api/FDB.cc
@@ -48,7 +48,6 @@ namespace fdb5 {
 
 FDB::FDB(const Config& config) :
     internal_(FDBFactory::instance().build(config)), dirty_(false), reportStats_(config.getBool("statistics", false)) {
-
     LibFdb5::instance().constructorCallback()(*internal_);
 }
 

--- a/src/fdb5/api/FDB.cc
+++ b/src/fdb5/api/FDB.cc
@@ -48,6 +48,7 @@ namespace fdb5 {
 
 FDB::FDB(const Config& config) :
     internal_(FDBFactory::instance().build(config)), dirty_(false), reportStats_(config.getBool("statistics", false)) {
+
     LibFdb5::instance().constructorCallback()(*internal_);
 }
 

--- a/src/fdb5/config/Config.cc
+++ b/src/fdb5/config/Config.cc
@@ -90,7 +90,6 @@ Config Config::expandConfig() const {
     // 'fdb_home' value in config
     if (!found) {
         PathName configDir = expandPath("~fdb/etc/fdb");
-
         for (const std::string& stem :
              {Main::instance().displayName(), Main::instance().name(), std::string("config")}) {
             for (const char* tail : {".yaml", ".json"}) {
@@ -106,7 +105,8 @@ Config Config::expandConfig() const {
     }
 
     if (found) {
-        return Config::make(actual_path, userConfig_ ? *userConfig_ : eckit::LocalConfiguration(), getString("fdb_home", ""));
+        return Config::make(actual_path, userConfig_ ? *userConfig_ : eckit::LocalConfiguration(),
+                            getString("fdb_home", ""));
     }
 
     // No expandable config available. Use the skeleton config.
@@ -126,7 +126,6 @@ PathName Config::expandPath(const std::string& path) const {
     ASSERT(path.size() > 0);
     if (path[0] == '~') {
         if (path.length() > 1 && path[1] != '/') {
-
             size_t slashpos = path.find('/');
             if (slashpos == std::string::npos)
                 slashpos = path.length();
@@ -137,7 +136,6 @@ PathName Config::expandPath(const std::string& path) const {
             if (has(key)) {
                 PathName newpath = getString(key);
                 newpath += path.substr(slashpos);
-
                 return newpath;
             }
         }
@@ -180,7 +178,6 @@ void Config::initializeSchemaPath() const {
         //       N.B. this uses Config expandPath()
         static std::string fdbSchemaFile =
             Resource<std::string>("fdbSchemaFile;$FDB_SCHEMA_FILE", "~fdb/etc/fdb/schema");
-        
         schemaPath_ = expandPath(fdbSchemaFile);
     }
 

--- a/src/fdb5/config/Config.h
+++ b/src/fdb5/config/Config.h
@@ -33,7 +33,7 @@ class Config : public eckit::LocalConfiguration {
 public:  // static methods
 
     static Config make(const eckit::PathName& path,
-                       const eckit::Configuration& userConfig = eckit::LocalConfiguration());
+                       const eckit::Configuration& userConfig = eckit::LocalConfiguration(), const std::string& fdb_home = "");
 
 public:  // methods
 

--- a/src/fdb5/config/Config.h
+++ b/src/fdb5/config/Config.h
@@ -33,7 +33,8 @@ class Config : public eckit::LocalConfiguration {
 public:  // static methods
 
     static Config make(const eckit::PathName& path,
-                       const eckit::Configuration& userConfig = eckit::LocalConfiguration(), const std::string& fdb_home = "");
+                       const eckit::Configuration& userConfig = eckit::LocalConfiguration(),
+                       const std::string& fdb_home            = "");
 
 public:  // methods
 

--- a/src/fdb5/toc/EnvVarFileSpaceHandler.cc
+++ b/src/fdb5/toc/EnvVarFileSpaceHandler.cc
@@ -28,15 +28,15 @@ namespace fdb5 {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-EnvVarFileSpaceHandler::EnvVarFileSpaceHandler() :
-    fdbFileSpaceSHandlerEnvVarName_(LibResource<std::string, LibFdb5>(
+EnvVarFileSpaceHandler::EnvVarFileSpaceHandler(const Config& config) : FileSpaceHandler(config), 
+    fdbFileSpaceSHandlerEnvVarName_(eckit::Resource<std::string>(
         "fdbFileSpaceSHandlerEnvVarName;$FDB_FILESPACEHANDLER_ENVVARNAME", "STHOST")) {}
 
 EnvVarFileSpaceHandler::~EnvVarFileSpaceHandler() {}
 
 
 PathName EnvVarFileSpaceHandler::select(const Key& key, const FileSpace& fs) const {
-    return FileSpaceHandler::lookup("WeightedRandom").selectFileSystem(key, fs);
+    return FileSpaceHandler::lookup("WeightedRandom", config_).selectFileSystem(key, fs);
 }
 
 eckit::PathName EnvVarFileSpaceHandler::selectFileSystem(const Key& key, const FileSpace& fs) const {

--- a/src/fdb5/toc/EnvVarFileSpaceHandler.cc
+++ b/src/fdb5/toc/EnvVarFileSpaceHandler.cc
@@ -28,9 +28,10 @@ namespace fdb5 {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-EnvVarFileSpaceHandler::EnvVarFileSpaceHandler(const Config& config) : FileSpaceHandler(config), 
-    fdbFileSpaceSHandlerEnvVarName_(eckit::Resource<std::string>(
-        "fdbFileSpaceSHandlerEnvVarName;$FDB_FILESPACEHANDLER_ENVVARNAME", "STHOST")) {}
+EnvVarFileSpaceHandler::EnvVarFileSpaceHandler(const Config& config) :
+    FileSpaceHandler(config),
+    fdbFileSpaceSHandlerEnvVarName_(
+        eckit::Resource<std::string>("fdbFileSpaceSHandlerEnvVarName;$FDB_FILESPACEHANDLER_ENVVARNAME", "STHOST")) {}
 
 EnvVarFileSpaceHandler::~EnvVarFileSpaceHandler() {}
 

--- a/src/fdb5/toc/EnvVarFileSpaceHandler.h
+++ b/src/fdb5/toc/EnvVarFileSpaceHandler.h
@@ -34,7 +34,7 @@ class EnvVarFileSpaceHandler : public FileSpaceHandler {
 
 public:  // methods
 
-    EnvVarFileSpaceHandler();
+    EnvVarFileSpaceHandler(const Config& config);
 
     ~EnvVarFileSpaceHandler() override;
 

--- a/src/fdb5/toc/ExpverFileSpaceHandler.cc
+++ b/src/fdb5/toc/ExpverFileSpaceHandler.cc
@@ -36,7 +36,8 @@ namespace fdb5 {
 
 ExpverFileSpaceHandler::ExpverFileSpaceHandler(const Config& config) :
     FileSpaceHandler(config),
-    fdbExpverFileSystems_(config.expandPath(eckit::Resource<std::string>("fdbExpverFileSystems;$FDB_EXPVER_FILE", "~fdb/etc/fdb/expver_to_fdb_root.map"))) {}
+    fdbExpverFileSystems_(config.expandPath(eckit::Resource<std::string>("fdbExpverFileSystems;$FDB_EXPVER_FILE",
+                                                                         "~fdb/etc/fdb/expver_to_fdb_root.map"))) {}
 
 ExpverFileSpaceHandler::~ExpverFileSpaceHandler() {}
 

--- a/src/fdb5/toc/ExpverFileSpaceHandler.cc
+++ b/src/fdb5/toc/ExpverFileSpaceHandler.cc
@@ -34,9 +34,9 @@ namespace fdb5 {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-ExpverFileSpaceHandler::ExpverFileSpaceHandler() :
-    fdbExpverFileSystems_(LibResource<PathName, LibFdb5>("fdbExpverFileSystems;$FDB_EXPVER_FILE",
-                                                         "~fdb/etc/fdb/expver_to_fdb_root.map")) {}
+ExpverFileSpaceHandler::ExpverFileSpaceHandler(const Config& config) :
+    FileSpaceHandler(config),
+    fdbExpverFileSystems_(config.expandPath(eckit::Resource<std::string>("fdbExpverFileSystems;$FDB_EXPVER_FILE", "~fdb/etc/fdb/expver_to_fdb_root.map"))) {}
 
 ExpverFileSpaceHandler::~ExpverFileSpaceHandler() {}
 
@@ -167,7 +167,7 @@ eckit::PathName ExpverFileSpaceHandler::append(const std::string& expver, const 
 }
 
 PathName ExpverFileSpaceHandler::select(const Key& key, const FileSpace& fs) const {
-    return FileSpaceHandler::lookup("WeightedRandom").selectFileSystem(key, fs);
+    return FileSpaceHandler::lookup("WeightedRandom", config_).selectFileSystem(key, fs);
 }
 
 static bool expver_is_valid(const std::string& str) {

--- a/src/fdb5/toc/ExpverFileSpaceHandler.h
+++ b/src/fdb5/toc/ExpverFileSpaceHandler.h
@@ -35,7 +35,7 @@ class ExpverFileSpaceHandler : public FileSpaceHandler {
 
 public:  // methods
 
-    ExpverFileSpaceHandler();
+    ExpverFileSpaceHandler(const Config& config);
 
     ~ExpverFileSpaceHandler() override;
 

--- a/src/fdb5/toc/FileSpace.cc
+++ b/src/fdb5/toc/FileSpace.cc
@@ -39,7 +39,7 @@ FileSpace::FileSpace(const std::string& name, const std::string& re, const std::
                      const std::vector<Root>& roots) :
     name_(name), handler_(handler), re_(re), roots_(roots) {}
 
-TocPath FileSpace::filesystem(const Key& key, const eckit::PathName& db) const {
+TocPath FileSpace::filesystem(const Config& config, const Key& key, const eckit::PathName& db) const {
     // check that the database isn't present already
     // if it is, then return that path
 
@@ -52,7 +52,7 @@ TocPath FileSpace::filesystem(const Key& key, const eckit::PathName& db) const {
     LOG_DEBUG_LIB(LibFdb5) << "FDB for key " << key << " not found, selecting a root" << std::endl;
     LOG_DEBUG_LIB(LibFdb5) << "FDB for key " << key << " not found, selecting a root" << std::endl;
 
-    return TocPath{FileSpaceHandler::lookup(handler_).selectFileSystem(key, *this) / db, ControlIdentifiers{}};
+    return TocPath{FileSpaceHandler::lookup(handler_, config).selectFileSystem(key, *this) / db, ControlIdentifiers{}};
 }
 
 std::vector<eckit::PathName> FileSpace::enabled(const ControlIdentifier& controlIdentifier) const {

--- a/src/fdb5/toc/FileSpace.h
+++ b/src/fdb5/toc/FileSpace.h
@@ -28,6 +28,7 @@
 
 namespace fdb5 {
 
+class Config;
 class FileSpaceHandler;
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -50,7 +51,7 @@ public:  // methods
     /// @note This method must be idempotent -- it returns always the same value after the first call
     /// @param key is a complete identifier for the first level of the schema
     /// @param db part of the full path
-    TocPath filesystem(const Key& key, const eckit::PathName& db) const;
+    TocPath filesystem(const Config& config, const Key& key, const eckit::PathName& db) const;
 
     void all(eckit::StringSet&) const;
     void enabled(const ControlIdentifier& controlIdentifier, eckit::StringSet&) const;

--- a/src/fdb5/toc/FileSpaceHandler.h
+++ b/src/fdb5/toc/FileSpaceHandler.h
@@ -20,6 +20,7 @@
 #include "eckit/types/Types.h"
 #include "eckit/utils/Regex.h"
 
+#include "fdb5/config/Config.h"
 #include "fdb5/toc/Root.h"
 
 namespace fdb5 {
@@ -35,7 +36,7 @@ class FileSpaceHandler : private eckit::NonCopyable {
 
 public:  // methods
 
-    static const FileSpaceHandler& lookup(const std::string& name);
+    static const FileSpaceHandler& lookup(const std::string& name, const Config& config);
     static void regist(const std::string& name, FileSpaceHandlerInstance* h);
     static void unregist(const std::string& name);
 
@@ -45,7 +46,9 @@ public:  // methods
 
 protected:  // methods
 
-    FileSpaceHandler();
+    FileSpaceHandler(const Config& config);
+
+    const Config& config_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -53,7 +56,7 @@ protected:  // methods
 class FileSpaceHandlerInstance {
 public:
 
-    const FileSpaceHandler& get();
+    const FileSpaceHandler& get(const Config& config);
 
 protected:
 
@@ -63,7 +66,7 @@ protected:
 
 private:
 
-    virtual FileSpaceHandler* make() const = 0;
+    virtual FileSpaceHandler* make(const Config& config) const = 0;
 
     std::string name_;
     mutable FileSpaceHandler* instance_;
@@ -77,7 +80,7 @@ public:
 
 private:
 
-    FileSpaceHandler* make() const override { return new T(); }
+    FileSpaceHandler* make(const Config& config) const override { return new T(config); }
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/toc/RootManager.cc
+++ b/src/fdb5/toc/RootManager.cc
@@ -607,7 +607,7 @@ TocPath RootManager::directory(const Key& key) {
 
     for (FileSpaceTable::const_iterator i = spacesTable_.begin(); i != spacesTable_.end(); ++i) {
         if (i->match(keystr)) {
-            TocPath db = i->filesystem(key, dbpath);
+            TocPath db = i->filesystem(config_, key, dbpath);
             LOG_DEBUG_LIB(LibFdb5) << "Database directory " << db.directory_ << std::endl;
             return db;
         }


### PR DESCRIPTION
In mars-client we need to support multiple fdb homes.
The schema path expansion was done al library level, thus not working with multiple homes.
This PR preserve the fdb_home keyword in the config and uses it in the schema path resolution.

<!-- readthedocs-preview ecmwf-fdb start -->
----
📚 Documentation preview 📚: https://ecmwf-fdb--128.com.readthedocs.build/en/128/

<!-- readthedocs-preview ecmwf-fdb end -->