### PR TITLE
Memonize TocCatalogueReader::axis() calls

### DIFF
--- a/src/fdb5/rules/Rule.cc
+++ b/src/fdb5/rules/Rule.cc
@@ -613,7 +613,6 @@ void RuleIndex::expand(const metkit::mars::MarsRequest& request, ReadVisitor& vi
 
         full.pushFrom(key);
 
-        bool idx = visitor.selectIndex(key, full);
         if (visitor.selectIndex(key, full)) {
             for (const auto& rule : rules_) {
                 rule->expand(request, visitor, full);

--- a/src/fdb5/toc/TocCatalogueReader.h
+++ b/src/fdb5/toc/TocCatalogueReader.h
@@ -12,21 +12,24 @@
 /// @author Baudouin Raoult
 /// @author Tiago Quintino
 /// @date   Mar 2016
-
-#ifndef fdb5_TocCatalogueReader_H
-#define fdb5_TocCatalogueReader_H
-
+#pragma once
+#include <cstddef>
 #include <iosfwd>
-#include <map>
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "eckit/filesystem/URI.h"
+#include "fdb5/config/Config.h"
 #include "fdb5/database/Catalogue.h"
+#include "fdb5/database/DbStats.h"
 #include "fdb5/database/Field.h"
 #include "fdb5/database/Index.h"
 #include "fdb5/database/Key.h"
 #include "fdb5/toc/TocCatalogue.h"
+#include "fdb5/toc/TocHandler.h"
 
 namespace fdb5 {
 
@@ -65,17 +68,17 @@ private:  // methods
 
 private:  // members
 
-    // Indexes matching current key. If there is a key remapping for a mounted
-    // SubToc, then this is stored alongside
+    /// Indexes matching current key. If there is a key remapping for a mounted
+    /// SubToc, then this is stored alongside
     std::vector<std::pair<Index, Key>*> matching_;
 
-    // All indexes
-    // If there is a key remapping for a mounted SubToc, this is stored alongside
+    /// All indexes
+    /// If there is a key remapping for a mounted SubToc, this is stored alongside
     mutable std::vector<std::pair<Index, Key>> indexes_;
+
+    mutable std::unordered_map<std::string, std::unique_ptr<eckit::DenseSet<std::string>>> axisCache_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace fdb5
-
-#endif


### PR DESCRIPTION
This should improve performance when calling inspect and repeatedly using the same Dataset Key and Collocation key.


Fixes: FDB-513

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-137
<!-- PREVIEW-URL_END -->