### PR TITLE
Occasional failure of RemoteFDB CI test.

### DIFF
--- a/tests/fdb/remote/test_remote_api.cc
+++ b/tests/fdb/remote/test_remote_api.cc
@@ -90,13 +90,16 @@ CASE("Remote protocol: the basics") {
 
     ListElement elem;
     size_t count = 0;
+    eckit::Log::info() << "Clientside list:"  << std::endl;
     while (it.next(elem)) {
-        eckit::Log::info() << elem << " " << elem.location() << std::endl;
+        eckit::Log::info() << "  " << elem << std::endl;
         count++;
     }
     EXPECT_EQUAL(count, Nfields);
 
     // -- retrieve all fields
+    eckit::Log::info() << "Clientside: start of fdb.retrieve."  << std::endl;
+
     std::unique_ptr<eckit::DataHandle> dh(fdb.retrieve(make_request(keys)));
 
     eckit::AutoClose closer(*dh);
@@ -108,7 +111,10 @@ CASE("Remote protocol: the basics") {
         EXPECT_EQUAL(retrieved_string, data_string);
     }
 
+    eckit::Log::info() << "Clientside: end of fdb.retrieve."  << std::endl;
+    
     /// @todo: add wipe when it is implemented.
+    eckit::Log::info() << "Clientside: reached end of test."  << std::endl;
 }
 
 }  // namespace fdb5::test


### PR DESCRIPTION
`FDB-491-remote-single-connection` test appears to fail occasionally on the ci. It does not appear to be platform dependent.

My hunch this is due to an inconsistency with remote FDB proper, rather than an error in how we conduct the test.  
Still investigating... will edit when I know more.

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-142
<!-- PREVIEW-URL_END -->