### PR TITLE
Fix for the libuuid cmake target to be properly picked up by dummy DAOS.

### DIFF
--- a/src/dummy_daos/CMakeLists.txt
+++ b/src/dummy_daos/CMakeLists.txt
@@ -15,7 +15,7 @@ ecbuild_add_library(
 
     PUBLIC_LIBS
         eckit
-        uuid
+        LibUUID
 
 )
 


### PR DESCRIPTION
<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-146
<!-- PREVIEW-URL_END -->