### PR TITLE
Make eccodes optional again

### DIFF
--- a/tests/fdb/tools/copy/CMakeLists.txt
+++ b/tests/fdb/tools/copy/CMakeLists.txt
@@ -1,9 +1,8 @@
-if (HAVE_FDB_BUILD_TOOLS)
+if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
     ecbuild_configure_file( fdb_copy.sh.in fdb_copy.sh @ONLY )
 
     ecbuild_add_test(
         TYPE SCRIPT
-        CONDITION HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB
         COMMAND fdb_copy.sh
         ENVIRONMENT "${test_environment}")
 endif()

--- a/tests/fdb/tools/reindex/CMakeLists.txt
+++ b/tests/fdb/tools/reindex/CMakeLists.txt
@@ -1,9 +1,8 @@
-if (HAVE_FDB_BUILD_TOOLS)
+if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
     ecbuild_configure_file( fdb_reindex.sh.in fdb_reindex.sh @ONLY )
 
     ecbuild_add_test(
         TYPE SCRIPT
-        CONDITION HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB
         COMMAND fdb_reindex.sh
         ENVIRONMENT "${test_environment}")
 endif()

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -29,10 +29,10 @@ if (HAVE_FDB_BUILD_TOOLS) # test scripts use the fdb tools
     add_subdirectory(FDB-241)
 
     if (HAVE_FDB_REMOTE)
-        add_subdirectory(FDB-258)
         add_subdirectory(FDB-419)
         
         if (HAVE_GRIB)
+            add_subdirectory(FDB-258)
             add_subdirectory(FDB-491)
         endif()
 


### PR DESCRIPTION
### Description

There have been a couple of test cases who relied on grib tools being available. Those test have again been place behind the correct feeature flags.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-172
<!-- PREVIEW-URL_END -->