### PR TITLE
FDB-564 Assert that the path provided to Config::make is a file.

### DIFF
--- a/src/fdb5/config/Config.cc
+++ b/src/fdb5/config/Config.cc
@@ -35,6 +35,7 @@ Config::Config() : schemaPath_(""), schemaPathInitialised_(false) {
 
 Config Config::make(const eckit::PathName& path, const eckit::Configuration& userConfig, const std::string& fdb_home) {
     LOG_DEBUG_LIB(LibFdb5) << "Using FDB configuration file: " << path << std::endl;
+    ASSERT(!path.realName().isDir());
     Config cfg{YAMLConfiguration(path)};
     cfg.set("configSource", path);
     if (!fdb_home.empty()) {


### PR DESCRIPTION
### Description

Asserts that the config files passed to Config::make are not directories to avoid problematic behaviour observed if mistakenly passing directories via the --source and --target arguments of fdb-copy.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-176
<!-- PREVIEW-URL_END -->