### PR TITLE
Fix build failure with z3fdb enabled and make

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ if (HAVE_PYTHON_ZARR_INTERFACE)
     )
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/wheel.stamp
-        COMMAND ${Python_INTERPRETER} -m build --wheel ${Z3FDB_STAGING} -o .
+        COMMAND ${Python_EXECUTABLE} -m build --wheel ${Z3FDB_STAGING} -o .
         COMMAND ${CMAKE_COMMAND} -E touch wheel.stamp
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         DEPENDS 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ if (HAVE_PYTHON_ZARR_INTERFACE)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         DEPENDS 
             ${_z3fdb_package_files}
-            $<TARGET_FILE:chunked_data_view_bindings>
+            chunked_data_view_bindings
         COMMENT "Building Python wheel for z3fdb..."
     )
     add_custom_target(z3fdb-wheel ALL DEPENDS ${CMAKE_BINARY_DIR}/wheel.stamp)

--- a/tests/pychunked_data_view/CMakeLists.txt
+++ b/tests/pychunked_data_view/CMakeLists.txt
@@ -2,7 +2,7 @@ function(add_py_test test)
     get_filename_component(stem ${test} NAME_WLE)
     add_test(
         NAME pychunked_data_view_${stem}
-        COMMAND ${Python_INTERPRETER}
+        COMMAND ${Python_EXECUTABLE}
             -m pytest
             --basetemp ${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp
             -vv -s ${CMAKE_CURRENT_SOURCE_DIR}/${test}

--- a/tests/z3fdb/CMakeLists.txt
+++ b/tests/z3fdb/CMakeLists.txt
@@ -2,7 +2,7 @@ function(add_py_test test)
     get_filename_component(stem ${test} NAME_WLE)
     add_test(
         NAME pychunked_data_view_${stem}
-        COMMAND ${Python_INTERPRETER}
+        COMMAND ${Python_EXECUTABLE}
             -m pytest
             --basetemp ${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp
             -vv -s ${CMAKE_CURRENT_SOURCE_DIR}/${test}


### PR DESCRIPTION
### Description

Now use a dependency that works with both ninja and make generators. Make cannot handle file level dependencies here and needs a target level dependency. Also fixes use of cmake features not available in min required version.

Commits
```
Fix use of CMake features from 3.30
Python_INTERPRETER was introduced in CMake 3.30. Now use
Python_EXECUTABLE whioch is compatible with currnetly set cmake minimum
version.
---
Fix build failure with z3fdb enabled and make
Now use a dependency that works with both ninja and make generators.
Make cannot handle file level dependencies here and needs a target level
depedency.
---
```
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-Z3FDB_BEGIN -->
🌈🌦️📖🚧 Documentation Z3FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/z3fdb/pull-requests/PR-220
<!-- PREVIEW-PUBLISH-Z3FDB_END -->

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-220
<!-- PREVIEW-PUBLISH-FDB_END -->