### PR TITLE
BugFix: Close all FDBFileHandle on TocStore destruction

### DIFF
--- a/src/fdb5/toc/TocStore.h
+++ b/src/fdb5/toc/TocStore.h
@@ -39,7 +39,7 @@ public:  // methods
 
     TocStore(const Key& key, const Config& config);
 
-    ~TocStore() override {}
+    ~TocStore() override { close(); }
 
     eckit::URI uri() const override;
     bool uriBelongs(const eckit::URI&) const override;


### PR DESCRIPTION
### Description
FDBFileHandles weren't closed and leaked across several executions of tests with a shared, long-living FDB object.
See ECKIT-670.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-Z3FDB_BEGIN -->
🌈🌦️📖🚧 Documentation Z3FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/z3fdb/pull-requests/PR-228
<!-- PREVIEW-PUBLISH-Z3FDB_END -->

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-228
<!-- PREVIEW-PUBLISH-FDB_END -->