### PR TITLE
Docs/fdb 504 envvar

### DIFF
--- a/docs/fdb/content/environment-variables.rst
+++ b/docs/fdb/content/environment-variables.rst
@@ -42,3 +42,12 @@ overridden by ``FDB_CONFIG``.
 ``FDB5_CONFIG_FILE``
 --------------------
 Deprecated. Equivalent to ``FDB_CONFIG_FILE``. If both are specified, ``FDB_CONFIG_FILE`` takes precedence over ``FDB5_CONFIG_FILE``.
+
+
+``FDB_SUB_TOCS``
+------------------
+
+If set to `1`, the FDB process will write to its own sub toc files instead of the main toc file.
+This mode is useful for avoiding contention on the main toc file when multiple FDB processes are writing concurrently.
+
+This variable overrides the `useSubToc` flag provided by the user config.

--- a/src/fdb5/LibFdb5.cc
+++ b/src/fdb5/LibFdb5.cc
@@ -101,28 +101,22 @@ static unsigned getUserEnvRemoteProtocol() {
     return 0;  // no version override
 }
 
-static bool getUserEnvSkipSanityCheck() {
-    return ::getenv("FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK");
-}
 
 RemoteProtocolVersion::RemoteProtocolVersion() {
-    static unsigned user  = getUserEnvRemoteProtocol();
-    static bool skipcheck = getUserEnvSkipSanityCheck();
+    static unsigned user = getUserEnvRemoteProtocol();
 
     if (not user) {
         used_ = defaulted();
         return;
     }
 
-    if (not skipcheck) {
-        bool valid = check(user, false);
-        if (not valid) {
-            std::ostringstream msg;
-            msg << "Unsupported FDB5 remote protocol version " << user << " - supported: " << supportedStr()
-                << std::endl;
-            throw eckit::BadValue(msg.str(), Here());
-        }
+    bool valid = check(user, false);
+    if (not valid) {
+        std::ostringstream msg;
+        msg << "Unsupported FDB5 remote protocol version " << user << " - supported: " << supportedStr() << std::endl;
+        throw eckit::BadValue(msg.str(), Here());
     }
+
     used_ = user;
 }
 

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -149,7 +149,10 @@ TocHandler::TocHandler(const eckit::PathName& directory, const Config& config) :
     dirty_(false) {
     // An override to enable using sub tocs without configurations being passed in, for ease
     // of debugging
-    const char* subTocOverride = ::getenv("FDB5_SUB_TOCS");
+    const char* subTocOverride = ::getenv("FDB_SUB_TOCS");
+    if (!subTocOverride) {
+        subTocOverride = ::getenv("FDB5_SUB_TOCS");
+    }
     if (subTocOverride) {
         useSubToc_ = true;
     }

--- a/tests/regressions/FDB-258/FDB-258.sh.in
+++ b/tests/regressions/FDB-258/FDB-258.sh.in
@@ -114,7 +114,7 @@ export FDB5_REMOTE_PROTOCOL_VERSION=2
 
 ! $fdbread mars.req out.grib
 
-export FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK=ON
+export FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK=ON # < no longer does anything.
 
 ! $fdbread mars.req out.grib
 


### PR DESCRIPTION
### Description

Depends on https://github.com/ecmwf/fdb/pull/229.

Does the following:
- Adds env var `FDB_SUB_TOCS` which from now should be preferred over `FDB5_SUB_TOCS`.
- Removed the var `FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK` and related code.
   - Because I do not believe there is a reason to not validate the protocol versions being used.
- Added some documentation to FDB_SUB_TOCS.
  - These ought to link to a more general discussion about tocs, subtocs and the POSIX backend to FDB in general, if such a page exists.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-Z3FDB_BEGIN -->
🌈🌦️📖🚧 Documentation Z3FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/z3fdb/pull-requests/PR-230
<!-- PREVIEW-PUBLISH-Z3FDB_END -->

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-230
<!-- PREVIEW-PUBLISH-FDB_END -->