### PR TITLE
workaround to try to stabilise fdb_test_remote_api on github runners

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,19 @@ endif()
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} )
 
+if (HAVE_FDB_REMOTE)
+    ecbuild_configure_file( fdb_remote_cleanup.sh.in fdb_remote_cleanup.sh @ONLY )
+
+    ecbuild_add_test(
+            TARGET         fdb_test_remote_cleanup
+            TYPE           SCRIPT
+            COMMAND        fdb_remote_cleanup.sh
+            TEST_PROPERTIES
+            RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
+            LABELS remotefdb
+        )
+endif()
+
 add_subdirectory( fdb )
 add_subdirectory( chunked_data_view )
 add_subdirectory( regressions )

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
         TEST_PROPERTIES
         TIMEOUT 300
         RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
-        # RUN_SERIAL TRUE
+        RUN_SERIAL TRUE
         LABELS remotefdb
     )
 endif()

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -21,7 +21,7 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
         TYPE           SCRIPT
         COMMAND        ${FDB_TEST_SERVER_SCRIPT}
         ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
-        TEST_DEPENDS   fdb_test_remote_api_bin
+        TEST_DEPENDS   "fdb_test_remote_cleanup;fdb_test_remote_api_bin"
         ENVIRONMENT    "${test_environment}"
         TEST_PROPERTIES
         TIMEOUT 300

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -26,6 +26,7 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
         TEST_PROPERTIES
         TIMEOUT 300
         RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
+        RUN_SERIAL TRUE
         LABELS remotefdb
     )
 endif()

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
         TEST_PROPERTIES
         TIMEOUT 300
         RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
-        RUN_SERIAL TRUE
+        # RUN_SERIAL TRUE
         LABELS remotefdb
     )
 endif()

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -16,18 +16,18 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
     ecbuild_configure_file( store.yaml.in store.yaml @ONLY )
     ecbuild_configure_file( client.yaml.in client.yaml @ONLY )
 
-    ecbuild_add_test(
-        TARGET         fdb_test_remote_api
-        TYPE           SCRIPT
-        COMMAND        ${FDB_TEST_SERVER_SCRIPT}
-        ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
-        TEST_DEPENDS   "fdb_test_remote_cleanup;fdb_test_remote_api_bin"
-        ENVIRONMENT    "${test_environment}"
-        TEST_PROPERTIES
-        TIMEOUT 300
-        RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
-        RUN_SERIAL TRUE
-        LABELS remotefdb
-    )
+    # ecbuild_add_test(
+    #     TARGET         fdb_test_remote_api
+    #     TYPE           SCRIPT
+    #     COMMAND        ${FDB_TEST_SERVER_SCRIPT}
+    #     ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
+    #     TEST_DEPENDS   "fdb_test_remote_cleanup;fdb_test_remote_api_bin"
+    #     ENVIRONMENT    "${test_environment}"
+    #     TEST_PROPERTIES
+    #     TIMEOUT 300
+    #     RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
+    #     RUN_SERIAL TRUE
+    #     LABELS remotefdb
+    # )
 endif()
 

--- a/tests/fdb_remote_cleanup.sh.in
+++ b/tests/fdb_remote_cleanup.sh.in
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+killall fdb-server || true

--- a/tests/regressions/FDB-419/CMakeLists.txt
+++ b/tests/regressions/FDB-419/CMakeLists.txt
@@ -17,6 +17,7 @@ ecbuild_add_test(
     SOURCES fdb_419_regression_test.cc
     LIBS fdb5 eckit metkit
     ENVIRONMENT FDB_SERVER_EXECUTABLE=$<TARGET_FILE:fdb-server>
+    TEST_DEPENDS  fdb_test_remote_cleanup
     ENVIRONMENT "${test_environment}"
     TEST_PROPERTIES
     RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests

--- a/tests/regressions/FDB-491/CMakeLists.txt
+++ b/tests/regressions/FDB-491/CMakeLists.txt
@@ -13,7 +13,7 @@ ecbuild_add_test(
     TYPE           SCRIPT
     COMMAND        ${FDB_TEST_SERVER_SCRIPT}
     ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
-    TEST_DEPENDS   fdb_test_remote_api_bin
+    TEST_DEPENDS   "fdb_test_remote_cleanup;fdb_test_remote_api_bin"
     ENVIRONMENT    "${test_environment}"
     TEST_PROPERTIES
     TIMEOUT 300

--- a/tests/regressions/FDB-595/CMakeLists.txt
+++ b/tests/regressions/FDB-595/CMakeLists.txt
@@ -6,6 +6,7 @@ ecbuild_add_test(
     TARGET         FDB-595
     TYPE           SCRIPT
     COMMAND        ${CMAKE_CURRENT_BINARY_DIR}/FDB-595.sh
+    TEST_DEPENDS   fdb_test_remote_cleanup
     ENVIRONMENT    "${test_environment}"
     TEST_PROPERTIES
     RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests

--- a/tests/regressions/FDB-610/CMakeLists.txt
+++ b/tests/regressions/FDB-610/CMakeLists.txt
@@ -21,6 +21,7 @@ ecbuild_add_test(
     TARGET         FDB-610
     TYPE           SCRIPT
     COMMAND        ${CMAKE_CURRENT_BINARY_DIR}/FDB-610.sh
+    TEST_DEPENDS   fdb_test_remote_cleanup
     ENVIRONMENT    "${test_environment}"
     TEST_PROPERTIES
     RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests


### PR DESCRIPTION
### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-Z3FDB_BEGIN -->
🌈🌦️📖🚧 Documentation Z3FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/z3fdb/pull-requests/PR-235
<!-- PREVIEW-PUBLISH-Z3FDB_END -->

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-235
<!-- PREVIEW-PUBLISH-FDB_END -->