### PR TITLE
fix: Disable findlibs package

### DIFF
--- a/tests/pyfdb/CMakeLists.txt
+++ b/tests/pyfdb/CMakeLists.txt
@@ -1,10 +1,13 @@
-function(add_py_test test)
+# Create the pytest-tmp folder for encompassing the different scenarios
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp")
+
+function(add_pyfdb_test scenario test)
     get_filename_component(stem ${test} NAME_WLE)
     add_test(
-        NAME pyfdb_${stem}
+        NAME ${scenario}_${stem}
         COMMAND ${Python_EXECUTABLE}
             -m pytest
-            --basetemp ${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp
+            --basetemp ${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp/${scenario}/
             -vv -s ${CMAKE_CURRENT_SOURCE_DIR}/${test}
     )
     set(_env
@@ -16,11 +19,11 @@ function(add_py_test test)
         "ECCODES_DIR=$<TARGET_FILE_DIR:eccodes>/.."
         "FINDLIBS_DISABLE_PACKAGE=yes"
     )
-    set_tests_properties(pyfdb_${stem}
+    set_tests_properties(${scenario}_${stem}
         PROPERTIES
-        RESOURCE_LOCK pytest
+        RESOURCE_LOCK ${scenario}
         ENVIRONMENT "${_env}"
-        LABELS pyfdb
+        LABELS ${scenario}
     )
 endfunction()
 
@@ -48,41 +51,13 @@ set(test_files
 )
 
 foreach(test_file ${test_files})
-    add_py_test(${test_file})
+    add_pyfdb_test("pyfdb" ${test_file})
 endforeach()
-
-# Testing of pyfdb docs
-function(add_rst_doc_test test)
-    get_filename_component(stem ${test} NAME_WLE)
-    add_test(
-        NAME pyfdb_doc_${stem}
-        COMMAND ${Python_EXECUTABLE}
-            -m pytest
-            --basetemp ${CMAKE_CURRENT_BINARY_DIR}/pytest-tmp
-            -vv -s ${CMAKE_CURRENT_SOURCE_DIR}/${test}
-    )
-    set(_env
-        "PYTHONPATH=${CMAKE_BINARY_DIR}/pyfdb-python-package-staging:${PYTHONPATH}"
-        #prevent findlibs in pyfdb to pickup any globally installed fdb
-        "FDB5_DIR=${CMAKE_BINARY_DIR}"
-        #prevent findlibs in eccodes-python to pickup any globally installed eccodes
-        "ECCODES_PYTHON_USE_FINDLIBS=1"
-        "ECCODES_DIR=$<TARGET_FILE_DIR:eccodes>/.."
-        "FINDLIBS_DISABLE_PACKAGE=yes"
-    )
-    set_tests_properties(pyfdb_doc_${stem}
-        PROPERTIES
-        RESOURCE_LOCK pytest
-        ENVIRONMENT "${_env}"
-        LABELS pyfdb_doc
-    )
-endfunction()
-
 
 set(doc_test_files
     ../../docs/pyfdb/examples.rst
 )
 
 foreach(test_file ${doc_test_files})
-    add_rst_doc_test(${test_file})
+    add_pyfdb_test("pyfdb_doc" ${test_file})
 endforeach()

--- a/tests/pyfdb/CMakeLists.txt
+++ b/tests/pyfdb/CMakeLists.txt
@@ -14,6 +14,7 @@ function(add_py_test test)
         #prevent findlibs in eccodes-python to pickup any globally installed eccodes
         "ECCODES_PYTHON_USE_FINDLIBS=1"
         "ECCODES_DIR=$<TARGET_FILE_DIR:eccodes>/.."
+        "FINDLIBS_DISABLE_PACKAGE=yes"
     )
     set_tests_properties(pyfdb_${stem}
         PROPERTIES
@@ -67,6 +68,7 @@ function(add_rst_doc_test test)
         #prevent findlibs in eccodes-python to pickup any globally installed eccodes
         "ECCODES_PYTHON_USE_FINDLIBS=1"
         "ECCODES_DIR=$<TARGET_FILE_DIR:eccodes>/.."
+        "FINDLIBS_DISABLE_PACKAGE=yes"
     )
     set_tests_properties(pyfdb_doc_${stem}
         PROPERTIES


### PR DESCRIPTION
### Description
For the execution of the test cases the FINDLIBS_DISABLE_PACKAGE=yes needs to be set, otherwise a non-local installation, e.g. from python site-packages is picked up during the execution of the tests.

Also a __init__.py was removed from the pyfdb_bindings module. This is not necessary and even breaking the local dev setup.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-251
<!-- PREVIEW-PUBLISH-FDB_END -->