### PR TITLE
feat: Added key method of ListElement

### DIFF
--- a/docs/pyfdb/examples.rst
+++ b/docs/pyfdb/examples.rst
@@ -527,19 +527,18 @@ You can use this directly to read the message represented by the ``ListElement``
         data_handle.close()
 
 
-If you want to access the keys of any given `ListElement`, you can use either
-the `combined_keys` or the `keys` method of the `ListElement` class. `keys`
-returns a `list` with 3 elements. Each entry is a dictionary, resembling the
-corresponding level of the `FDB` schema, e.g., the first entry contains all
-MARS keys of the first level, etc. In case the list call specifies `level=2` or
-`level=1`, the entries of the dictionaries linked to the lower levels are
+If you want to access the keys of any given ``ListElement``, you can use either
+the ``combined_key`` or the ``keys`` method of the ``ListElement`` class. ``keys``
+returns a ``list`` with 3 elements. Each entry is a dictionary, resembling the
+corresponding level of the ``FDB`` schema, e.g., the first entry contains all
+MARS keys of the first level, etc. In case the list call specifies ``level=2`` or
+``level=1``, the entries of the dictionaries linked to the lower levels are
 empty.
 
 .. code-block:: python
 
     fdb = pyfdb.FDB(fdb_config_path)
 
-    list_iterator = fdb.list(selection, level=2)
     selection = {
             "type": "an",
             "class": "ea",
@@ -552,27 +551,30 @@ empty.
             "param": ["167", "131", "132"],
             "time": "1800",
     }
+    list_iterator = fdb.list(selection, level=2)
 
     for el in list_iterator:
         keys = el.keys()
         print(keys)
 
-For a single element of this `list_iterator` its keys would have the following structure:
+For a single element of this ``list_iterator`` its keys would have the following structure:
 
 :: 
+
     ...
     [{'class': 'ea', 'date': '20200101', 'domain': 'g', 'expver': '0001', 'stream': 'oper', 'time': '1800'}, {'levtype': 'sfc', 'type': 'an'}, {}]
     ...
 
-If we called `fdb.list` with `level=1`, the result would have the following structure:
+If we called ``fdb.list`` with ``level=1``, the result would have the following structure:
 
 :: 
+
     ...
     [{'class': 'ea', 'date': '20200101', 'domain': 'g', 'expver': '0001', 'stream': 'oper', 'time': '1800'}, {}, {}]
     ...
 
-`combined_keys` is a convenience method for combining all dictionaries of the
-`keys` function into a single dictionary.
+``combined_key`` is a convenience method for combining all dictionaries of the
+``keys`` function into a single dictionary.
 
 
 .. clear-namespace

--- a/docs/pyfdb/examples.rst
+++ b/docs/pyfdb/examples.rst
@@ -526,6 +526,55 @@ You can use this directly to read the message represented by the ``ListElement``
         assert data_handle.read(4) == b"GRIB"
         data_handle.close()
 
+
+If you want to access the keys of any given `ListElement`, you can use either
+the `combined_keys` or the `keys` method of the `ListElement` class. `keys`
+returns a `list` with 3 elements. Each entry is a dictionary, resembling the
+corresponding level of the `FDB` schema, e.g., the first entry contains all
+MARS keys of the first level, etc. In case the list call specifies `level=2` or
+`level=1`, the entries of the dictionaries linked to the lower levels are
+empty.
+
+.. code-block:: python
+
+    fdb = pyfdb.FDB(fdb_config_path)
+
+    list_iterator = fdb.list(selection, level=2)
+    selection = {
+            "type": "an",
+            "class": "ea",
+            "domain": "g",
+            "expver": "0001",
+            "stream": "oper",
+            "date": "20200101",
+            "levtype": "sfc",
+            "step": "0",
+            "param": ["167", "131", "132"],
+            "time": "1800",
+    }
+
+    for el in list_iterator:
+        keys = el.keys()
+        print(keys)
+
+For a single element of this `list_iterator` its keys would have the following structure:
+
+:: 
+    ...
+    [{'class': 'ea', 'date': '20200101', 'domain': 'g', 'expver': '0001', 'stream': 'oper', 'time': '1800'}, {'levtype': 'sfc', 'type': 'an'}, {}]
+    ...
+
+If we called `fdb.list` with `level=1`, the result would have the following structure:
+
+:: 
+    ...
+    [{'class': 'ea', 'date': '20200101', 'domain': 'g', 'expver': '0001', 'stream': 'oper', 'time': '1800'}, {}, {}]
+    ...
+
+`combined_keys` is a convenience method for combining all dictionaries of the
+`keys` function into a single dictionary.
+
+
 .. clear-namespace
 
 .. _inspect_label:

--- a/src/pyfdb/pyfdb_iterator.py
+++ b/src/pyfdb/pyfdb_iterator.py
@@ -47,18 +47,90 @@ class ListElement:
         self._element: _ListElement = list_element
 
     def has_location(self) -> bool:
+        """
+        Does the `ListElement` have a location
+
+        Returns
+        -------
+        `bool`
+            `True` if this element has a location, `False` otherwise.
+
+        Note
+        ----
+        Only for `ListElement`s which are on the third level of the schema.
+        """
         return self._element.has_location()
 
-    def offset(self) -> int:
-        return self._element.offset()
+    def offset(self) -> Optional[int]:
+        """
+        Offset within the file associated with the `ListElement`
 
-    def length(self) -> int:
-        return self._element.length()
+        Returns
+        -------
+        `Optional[int]`
+            Offset in bytes in the data file of the FDB, if `ListElement` is on `level` 3, None otherwise.
+
+        Note
+        ----
+        Only for `ListElement`s which are on the third level of the schema.
+        """
+        if self.has_location():
+            return self._element.offset()
+        logger.info("Asking for offset on list element without location. Did you specify `level=3` in a list call?")
+        return None
+
+    def length(self) -> Optional[int]:
+        """
+        Size of the `ListElement` within the file associated.
+
+        Returns
+        -------
+        `Optional[int]`
+            Size in bytes in the data file of the FDB, if `ListElement` is on `level` 3, None otherwise.
+
+        Note
+        ----
+        Only for `ListElement`s which are on the third level of the schema.
+        """
+        if self.has_location():
+            return self._element.length()
+        logger.info("Asking for length on list element without location. Did you specify `level=3` in a list call?")
+        return None
+
+    def key(self) -> dict[str, str]:
+        """
+        Return the MARS keys of the `ListElement`
+
+        Returns
+        -------
+        `dict[str, str]`
+            Dictionary containing all metadata for the `ListElement`
+
+        Note
+        ----
+        Depending on the `level` specified in the `list` command, only the keys for the corresponding
+        level are returned.
+
+        Examples
+        --------
+        >>> list_iterator = fdb.list(selection, level=3)
+        >>> assert list_iterator
+
+        >>> elements = list(list_iterator)
+
+        >>> for element in elements:
+        >>>     print(element.key())
+
+        Output:
+
+        ``{ 'class': 'ea', 'date': '20200104', ... , 'type': 'an' }``
+        """
+        return self._element.key()
 
     @property
     def data_handle(self) -> Optional[DataHandle]:
         """
-        Access the DataHandle
+        Access the `DataHandle`
 
         Returns
         -------

--- a/src/pyfdb/pyfdb_iterator.py
+++ b/src/pyfdb/pyfdb_iterator.py
@@ -97,7 +97,7 @@ class ListElement:
         logger.info("Asking for length on list element without location. Did you specify `level=3` in a list call?")
         return None
 
-    def key(self) -> dict[str, str]:
+    def combined_key(self) -> dict[str, str]:
         """
         Return the MARS keys of the `ListElement`
 
@@ -108,8 +108,9 @@ class ListElement:
 
         Note
         ----
-        Depending on the `level` specified in the `list` command, only the keys for the corresponding
-        level are returned.
+        Depending on the `level` specified in the `list` command, the returned dictionary contains
+        all available keys from schema levels up to and including the requested level; keys that
+        exist only at deeper levels are omitted.
 
         Examples
         --------
@@ -119,13 +120,53 @@ class ListElement:
         >>> elements = list(list_iterator)
 
         >>> for element in elements:
-        >>>     print(element.key())
+        >>>     print(element.combined_key())
 
         Output:
 
-        ``{ 'class': 'ea', 'date': '20200104', ... , 'type': 'an' }``
+        ``
+        ...
+        { 'class': 'ea', 'date': '20200104', ... , 'type': 'an' }
+        ...
+        ``
         """
-        return self._element.key()
+        return self._element.combined_key()
+
+    def keys(self) -> list[dict[str, str]]:
+        """
+        Return the MARS keys of the `ListElement` separated by their level in the schema.
+
+        Returns
+        -------
+        `list[dict[str, str]]`
+            List containing MARS keys and their values for the `ListElement`. The keys are split
+            by their level in the schema
+
+        Note
+        ----
+        Depending on the `level` specified in the `list` command, the returned dictionary contains
+        all available keys from schema levels up to and including the requested level; keys that
+        exist only at deeper levels are omitted.
+
+        Examples
+        --------
+        >>> list_iterator = fdb.list(selection, level=3)
+        >>> assert list_iterator
+
+        >>> elements = list(list_iterator)
+
+        >>> for element in elements:
+        >>>     print(element.keys())
+
+        Output:
+
+        ``
+        ...
+        [{'class': 'ea', ... , 'time': '2100'}, {'levtype': 'sfc', 'type': 'an'}, {'param': '167', 'step': '0'}]
+        ...
+        ``
+        """
+        return self._element.keys()
 
     @property
     def data_handle(self) -> Optional[DataHandle]:

--- a/src/pyfdb_bindings/bindings.cc
+++ b/src/pyfdb_bindings/bindings.cc
@@ -308,6 +308,16 @@ PYBIND11_MODULE(pyfdb_bindings, m) {
         .def("has_location", &fdb5::ListElement::hasLocation)
         .def("offset", [](const fdb5::ListElement& list_element) -> long long { return list_element.offset(); })
         .def("length", [](const fdb5::ListElement& list_element) -> long long { return list_element.length(); })
+        .def("key",
+             [](const fdb5::ListElement& list_element) {
+                 const auto combined_key = list_element.combinedKey();
+                 std::map<std::string, std::string> result;
+
+                 for (const auto& [key, value] : combined_key) {
+                     result.emplace(key, value);
+                 }
+                 return result;
+             })
         .def("uri",
              [](const fdb5::ListElement& list_element) -> std::optional<eckit::URI> {
                  try {

--- a/src/pyfdb_bindings/bindings.cc
+++ b/src/pyfdb_bindings/bindings.cc
@@ -308,7 +308,21 @@ PYBIND11_MODULE(pyfdb_bindings, m) {
         .def("has_location", &fdb5::ListElement::hasLocation)
         .def("offset", [](const fdb5::ListElement& list_element) -> long long { return list_element.offset(); })
         .def("length", [](const fdb5::ListElement& list_element) -> long long { return list_element.length(); })
-        .def("key",
+        .def("keys",
+             [](const fdb5::ListElement& list_element) {
+                 const auto keys = list_element.keys();
+                 std::array<std::map<std::string, std::string>, 3> result;
+
+                 for (std::size_t i = 0; i < 3; ++i) {
+                     std::map<std::string, std::string> mapped_key;
+                     for (const auto& [key, value] : keys[i]) {
+                         mapped_key.emplace(key, value);
+                     }
+                     result[i] = mapped_key;
+                 }
+                 return result;
+             })
+        .def("combined_key",
              [](const fdb5::ListElement& list_element) {
                  const auto combined_key = list_element.combinedKey();
                  std::map<std::string, std::string> result;

--- a/tests/pyfdb/integration/test_list.py
+++ b/tests/pyfdb/integration/test_list.py
@@ -46,6 +46,33 @@ def test_list_partial(read_only_fdb_setup):
     assert len(elements) == 32
 
 
+@pytest.mark.parametrize("level, expected_key_elements", [(3, 10), (2, 8), (1, 6)])
+def test_list_partial_contains_key(read_only_fdb_setup, level, expected_key_elements):
+    fdb = FDB(read_only_fdb_setup)
+
+    selection = {"type": "an"}
+
+    elements = list(fdb.list(selection, level=level))
+
+    for element in elements:
+        print(f"Element Offset: {element.offset}, Element Length: {element.length}, Element Key: {element.key}")
+
+        if level == 3 or level == 2:
+            assert "type" in element.key()
+            assert element.key()["type"] == "an"
+        else:
+            assert "type" not in element.key()
+
+        if level == 3:
+            assert element.offset() is not None
+            assert element.length() is not None
+        else:
+            assert element.offset() is None
+            assert element.length() is None
+
+        assert len(element.key()) == expected_key_elements
+
+
 def test_read_only_attributes_list_element(read_only_fdb_setup):
     fdb = FDB(read_only_fdb_setup)
 

--- a/tests/pyfdb/integration/test_list.py
+++ b/tests/pyfdb/integration/test_list.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyfdb import FDB
 
 
@@ -47,7 +48,7 @@ def test_list_partial(read_only_fdb_setup):
 
 
 @pytest.mark.parametrize("level, expected_key_elements", [(3, 10), (2, 8), (1, 6)])
-def test_list_partial_contains_key(read_only_fdb_setup, level, expected_key_elements):
+def test_list_partial_contains_combined_key(read_only_fdb_setup, level, expected_key_elements):
     fdb = FDB(read_only_fdb_setup)
 
     selection = {"type": "an"}
@@ -55,13 +56,16 @@ def test_list_partial_contains_key(read_only_fdb_setup, level, expected_key_elem
     elements = list(fdb.list(selection, level=level))
 
     for element in elements:
-        print(f"Element Offset: {element.offset}, Element Length: {element.length}, Element Key: {element.key}")
+        print(
+            f"Element Offset: {element.offset()}, Element Length: {element.length()}, Element Key: {element.combined_key()}"
+        )
+        combined_key = element.combined_key()
 
         if level == 3 or level == 2:
-            assert "type" in element.key()
-            assert element.key()["type"] == "an"
+            assert "type" in combined_key
+            assert combined_key["type"] == "an"
         else:
-            assert "type" not in element.key()
+            assert "type" not in combined_key
 
         if level == 3:
             assert element.offset() is not None
@@ -70,7 +74,44 @@ def test_list_partial_contains_key(read_only_fdb_setup, level, expected_key_elem
             assert element.offset() is None
             assert element.length() is None
 
-        assert len(element.key()) == expected_key_elements
+        assert len(combined_key) == expected_key_elements
+
+
+@pytest.mark.parametrize("level", [3, 2, 1])
+def test_list_partial_contains_keys(read_only_fdb_setup, level):
+    fdb = FDB(read_only_fdb_setup)
+
+    selection = {"type": "an"}
+
+    elements = list(fdb.list(selection, level=level))
+
+    for element in elements:
+        print(f"Element Offset: {element.offset()}, Element Length: {element.length()}, Element Key: {element.keys()}")
+        keys = element.keys()
+
+        # type is part of the second level
+        if level == 3:
+            assert "type" in element.keys()[1]
+            assert keys[1]["type"] == "an"
+            assert len(keys[0]) == 6
+            assert len(keys[1]) == 2
+            assert len(keys[2]) == 2
+            assert element.offset() is not None
+            assert element.length() is not None
+        elif level == 2:
+            assert "type" in element.keys()[1]
+            assert keys[1]["type"] == "an"
+            assert len(keys[0]) == 6
+            assert len(keys[1]) == 2
+            assert keys[2] == {}
+            assert element.offset() is None
+            assert element.length() is None
+        else:
+            assert len(element.keys()[0]) == 6
+            assert keys[1] == {}
+            assert keys[2] == {}
+            assert element.offset() is None
+            assert element.length() is None
 
 
 def test_read_only_attributes_list_element(read_only_fdb_setup):


### PR DESCRIPTION
### Description

For a ListElement we are now able to query the keys. The keys of the ListElement are returned as a dict[str, str] and resemble the MARS keys on the individual level of the Schema.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/fdb/pull-requests/PR-257
<!-- PREVIEW-PUBLISH-FDB_END -->