### PR TITLE
fix: Wrong path for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
       artifact-id: ${{ needs.build-fdb.outputs.artifact-id }}
       space: docs
       name: fdb
-      path: "/"
+      path: ""
       id: ${{ github.ref_name }}
       softlink: ${{ github.ref_name == 'master'   && 'stable'
                  || github.ref_name == 'develop' && 'latest' }}


### PR DESCRIPTION
### Description
Inserted the wrong path for the remote upload. This fixes this.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-264
<!-- PREVIEW-PUBLISH-FDB_END -->