### PR TITLE
add control flags to fdb remote networks

### DIFF
--- a/src/fdb5/api/FDBFactory.cc
+++ b/src/fdb5/api/FDBFactory.cc
@@ -28,22 +28,8 @@ namespace fdb5 {
 //----------------------------------------------------------------------------------------------------------------------
 
 
-FDBBase::FDBBase(const Config& config, const std::string& name) : name_(name), config_(config) {
-
-    bool writable = config.getBool("writable", true);
-    bool visitable = config.getBool("visitable", true);
-    if (!config.getBool("list", visitable)) {
-        controlIdentifiers_ |= ControlIdentifier::List;
-    }
-    if (!config.getBool("retrieve", visitable)) {
-        controlIdentifiers_ |= ControlIdentifier::Retrieve;
-    }
-    if (!config.getBool("archive", writable)) {
-        controlIdentifiers_ |= ControlIdentifier::Archive;
-    }
-    if (!config.getBool("wipe", writable)) {
-        controlIdentifiers_ |= ControlIdentifier::Wipe;
-    }
+FDBBase::FDBBase(const Config& config, const std::string& name) :
+    name_(name), config_(config), controlIdentifiers_(config) {
 
     LOG_DEBUG_LIB(LibFdb5) << "FDBBase: " << config << std::endl;
 }

--- a/src/fdb5/api/FDBFactory.cc
+++ b/src/fdb5/api/FDBFactory.cc
@@ -29,7 +29,7 @@ namespace fdb5 {
 
 
 FDBBase::FDBBase(const Config& config, const std::string& name) :
-    name_(name), config_(config), controlIdentifiers_(config) {
+    name_(name), config_(config), controlIdentifiers_(ControlIdentifiers::parse(config)) {
 
     LOG_DEBUG_LIB(LibFdb5) << "FDBBase: " << config << std::endl;
 }

--- a/src/fdb5/api/helpers/ControlIterator.cc
+++ b/src/fdb5/api/helpers/ControlIterator.cc
@@ -86,6 +86,24 @@ ControlIdentifiers::ControlIdentifiers(eckit::Stream& s) {
     s >> value_;
 }
 
+ControlIdentifiers::ControlIdentifiers(const eckit::LocalConfiguration& config) : value_(0) {
+
+    bool writable = config.getBool("writable", true);
+    bool visitable = config.getBool("visitable", true);
+    if (!config.getBool("list", visitable)) {
+        value_ |= static_cast<value_type>(ControlIdentifier::List);
+    }
+    if (!config.getBool("retrieve", visitable)) {
+        value_ |= static_cast<value_type>(ControlIdentifier::Retrieve);
+    }
+    if (!config.getBool("archive", writable)) {
+        value_ |= static_cast<value_type>(ControlIdentifier::Archive);
+    }
+    if (!config.getBool("wipe", writable)) {
+        value_ |= static_cast<value_type>(ControlIdentifier::Wipe);
+    }
+}
+
 ControlIdentifiers& ControlIdentifiers::operator|=(const ControlIdentifier& val) {
     value_ |= static_cast<value_type>(val);
     return *this;

--- a/src/fdb5/api/helpers/ControlIterator.cc
+++ b/src/fdb5/api/helpers/ControlIterator.cc
@@ -32,6 +32,33 @@ eckit::Stream& operator>>(eckit::Stream& s, ControlAction& a) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
+std::ostream& operator<<(std::ostream& s, const ControlIdentifier& i) {
+    switch (i) {
+        case ControlIdentifier::None:
+            s << "None";
+            break;
+        case ControlIdentifier::List:
+            s << "List";
+            break;
+        case ControlIdentifier::Retrieve:
+            s << "Retrieve";
+            break;
+        case ControlIdentifier::Archive:
+            s << "Archive";
+            break;
+        case ControlIdentifier::Wipe:
+            s << "Wipe";
+            break;
+        case ControlIdentifier::UniqueRoot:
+            s << "UniqueRoot";
+            break;
+    }
+    s << "(" << static_cast<typename std::underlying_type<ControlIdentifier>::type>(i) << ")";
+    return s;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
 ControlIdentifierIterator::ControlIdentifierIterator(const ControlIdentifiers& identifiers) :
     value_(0), remaining_(identifiers.value_) {
 

--- a/src/fdb5/api/helpers/ControlIterator.cc
+++ b/src/fdb5/api/helpers/ControlIterator.cc
@@ -52,6 +52,9 @@ std::ostream& operator<<(std::ostream& s, const ControlIdentifier& i) {
         case ControlIdentifier::UniqueRoot:
             s << "UniqueRoot";
             break;
+        case ControlIdentifier::UnsafeWipeAll:
+            s << "UnsafeWipeAll";
+            break;
     }
     s << "(" << static_cast<typename std::underlying_type<ControlIdentifier>::type>(i) << ")";
     return s;
@@ -113,22 +116,31 @@ ControlIdentifiers::ControlIdentifiers(eckit::Stream& s) {
     s >> value_;
 }
 
-ControlIdentifiers::ControlIdentifiers(const eckit::LocalConfiguration& config) : value_(0) {
+ControlIdentifiers ControlIdentifiers::parse(const eckit::LocalConfiguration& config, bool unsafeWipeAllDefault) {
+    ControlIdentifiers identifiers;
 
     bool writable = config.getBool("writable", true);
     bool visitable = config.getBool("visitable", true);
     if (!config.getBool("list", visitable)) {
-        value_ |= static_cast<value_type>(ControlIdentifier::List);
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::List);
     }
     if (!config.getBool("retrieve", visitable)) {
-        value_ |= static_cast<value_type>(ControlIdentifier::Retrieve);
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::Retrieve);
     }
     if (!config.getBool("archive", writable)) {
-        value_ |= static_cast<value_type>(ControlIdentifier::Archive);
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::Archive);
     }
     if (!config.getBool("wipe", writable)) {
-        value_ |= static_cast<value_type>(ControlIdentifier::Wipe);
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::Wipe);
     }
+    if (!config.getBool("wipe", writable)) {
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::Wipe);
+    }
+    // Unsafe Wipe all is disabled by default, unless explicitly enabled in the configuration file
+    if (!config.getBool("unsafeWipeAll", unsafeWipeAllDefault)) {
+        identifiers.value_ |= static_cast<value_type>(ControlIdentifier::UnsafeWipeAll);
+    }
+    return identifiers;
 }
 
 ControlIdentifiers& ControlIdentifiers::operator|=(const ControlIdentifier& val) {

--- a/src/fdb5/api/helpers/ControlIterator.h
+++ b/src/fdb5/api/helpers/ControlIterator.h
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 
+#include "eckit/config/LocalConfiguration.h"
 #include "eckit/filesystem/URI.h"
 
 #include "fdb5/api/helpers/APIIterator.h"
@@ -95,6 +96,7 @@ public:
     ControlIdentifiers();
     ControlIdentifiers(const ControlIdentifier& val);
     ControlIdentifiers(eckit::Stream& s);
+    ControlIdentifiers(const eckit::LocalConfiguration& config);
 
     ControlIdentifiers& operator|=(const ControlIdentifier& val);
     ControlIdentifiers operator|(const ControlIdentifier& val);

--- a/src/fdb5/api/helpers/ControlIterator.h
+++ b/src/fdb5/api/helpers/ControlIterator.h
@@ -53,6 +53,8 @@ enum class ControlIdentifier : uint16_t {
     UniqueRoot = 1 << 4
 };
 
+std::ostream& operator<<(std::ostream& s, const ControlIdentifier& m);
+
 static const std::initializer_list<ControlIdentifier> ControlIdentifierList{
     ControlIdentifier::List, ControlIdentifier::Retrieve, ControlIdentifier::Archive, ControlIdentifier::Wipe,
     ControlIdentifier::UniqueRoot};

--- a/src/fdb5/api/helpers/ControlIterator.h
+++ b/src/fdb5/api/helpers/ControlIterator.h
@@ -50,14 +50,15 @@ enum class ControlIdentifier : uint16_t {
     Retrieve = 1 << 1,
     Archive = 1 << 2,
     Wipe = 1 << 3,
-    UniqueRoot = 1 << 4
+    UniqueRoot = 1 << 4,
+    UnsafeWipeAll = 1 << 5
 };
 
 std::ostream& operator<<(std::ostream& s, const ControlIdentifier& m);
 
 static const std::initializer_list<ControlIdentifier> ControlIdentifierList{
-    ControlIdentifier::List, ControlIdentifier::Retrieve, ControlIdentifier::Archive, ControlIdentifier::Wipe,
-    ControlIdentifier::UniqueRoot};
+    ControlIdentifier::List, ControlIdentifier::Retrieve,   ControlIdentifier::Archive,
+    ControlIdentifier::Wipe, ControlIdentifier::UniqueRoot, ControlIdentifier::UnsafeWipeAll};
 //----------------------------------------------------------------------------------------------------------------------
 
 // An iterator to facilitate working with the ControlIdentifiers structure
@@ -98,7 +99,8 @@ public:
     ControlIdentifiers();
     ControlIdentifiers(const ControlIdentifier& val);
     ControlIdentifiers(eckit::Stream& s);
-    ControlIdentifiers(const eckit::LocalConfiguration& config);
+
+    static ControlIdentifiers parse(const eckit::LocalConfiguration& config, bool unsafeWipeAllDefault = true);
 
     ControlIdentifiers& operator|=(const ControlIdentifier& val);
     ControlIdentifiers operator|(const ControlIdentifier& val);

--- a/src/fdb5/api/local/QueryVisitor.h
+++ b/src/fdb5/api/local/QueryVisitor.h
@@ -16,9 +16,9 @@
 /// @author Simon Smart
 /// @date   November 2018
 
-#ifndef fdb5_api_local_QueryVisitor_H
-#define fdb5_api_local_QueryVisitor_H
+#pragma once
 
+#include <mutex>
 #include <tuple>
 #include <unordered_map>
 
@@ -49,6 +49,7 @@ protected:  // methods
 
     const metkit::mars::MarsRequest& canonicalise(const Rule& rule) const {
         bool success;
+        std::lock_guard<std::mutex> lock(canonicalisedMutex_);
         auto it = canonicalised_.find(&rule.registry());
         if (it == canonicalised_.end()) {
             std::tie(it, success) = canonicalised_.emplace(&rule.registry(), rule.registry().canonicalise(request_));
@@ -67,11 +68,10 @@ private:  // members
 
     /// Cache of canonicalised requests
     mutable std::unordered_map<const TypesRegistry*, metkit::mars::MarsRequest> canonicalised_;
+    mutable std::mutex canonicalisedMutex_;  ///< Protects canonicalised_ map
 };
 
 
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace fdb5::api::local
-
-#endif

--- a/src/fdb5/remote/FdbServer.cc
+++ b/src/fdb5/remote/FdbServer.cc
@@ -86,7 +86,7 @@ private:  // methods
 private:  // members
 
     eckit::net::TCPSocket socket_;
-    eckit::LocalConfiguration config_;
+    Config config_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/FdbServer.h
+++ b/src/fdb5/remote/FdbServer.h
@@ -45,7 +45,7 @@ private:  // methods
     void run() override;
 
     eckit::net::TCPSocket socket_;
-    eckit::LocalConfiguration config_;
+    Config config_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/client/RemoteCatalogue.h
+++ b/src/fdb5/remote/client/RemoteCatalogue.h
@@ -106,10 +106,6 @@ private:
     // not implemented since the catalogue traversal is performed on the remote side
     std::optional<Axis> computeAxis(const std::string& keyword) const override { NOTIMP; }
 
-protected:
-
-    ControlIdentifiers controlIdentifiers_;
-
 private:
 
     Key currentIndexKey_;

--- a/src/fdb5/remote/server/CatalogueHandler.cc
+++ b/src/fdb5/remote/server/CatalogueHandler.cc
@@ -9,7 +9,7 @@
  */
 
 #include "fdb5/remote/server/CatalogueHandler.h"
-#include "eckit/serialisation/ResizableMemoryStream.h"
+
 #include "fdb5/LibFdb5.h"
 #include "fdb5/api/FDBFactory.h"
 #include "fdb5/api/helpers/FDBToolRequest.h"
@@ -24,6 +24,7 @@
 #include "eckit/net/NetMask.h"
 #include "eckit/net/TCPSocket.h"
 #include "eckit/serialisation/MemoryStream.h"
+#include "eckit/serialisation/ResizableMemoryStream.h"
 #include "eckit/utils/Literals.h"
 
 #include <future>
@@ -44,7 +45,26 @@ namespace fdb5::remote {
 // ***************************************************************************************
 
 CatalogueHandler::CatalogueHandler(eckit::net::TCPSocket& socket, const Config& config) :
-    ServerConnection(socket, config), fdbControlConnection_(false), fdbDataConnection_(false) {}
+    ServerConnection(socket, config), fdbControlConnection_(false), fdbDataConnection_(false) {
+
+    eckit::net::IPAddress clientIPaddress{controlSocket_.remoteAddr()};
+
+    clientNetwork_ = "";
+    if (config_.has("networks")) {
+        for (const auto& net : config_.getSubConfigurations("networks")) {
+            if (net.has("name") && net.has("netmask")) {
+                eckit::net::NetMask netmask{net.getString("netmask")};
+                if (netmask.contains(clientIPaddress)) {
+                    clientNetwork_ = net.getString("name");
+                    controlIdentifiers_ = ControlIdentifiers(net);
+                    break;
+                }
+            }
+        }
+    }
+
+    LOG_DEBUG_LIB(LibFdb5) << "Client " << clientIPaddress << " from network '" << clientNetwork_ << "'" << std::endl;
+}
 
 CatalogueHandler::~CatalogueHandler() {}
 
@@ -72,7 +92,6 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
             case Message::Stores:  // request the list of FDB stores and the corresponging endpoints
                 stores(clientID, requestID);
                 return Handled::Replied;
-
 
             case Message::Archive:  // notification that the client is starting to send data locations for archival
                 archiver();
@@ -132,28 +151,47 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 return Handled::Replied;
 
             case Message::Wipe:  // Initial wipe request
-                wipe(clientID, requestID, std::move(payload));
-                return Handled::Yes;
+                if (isWipeEnabled(clientID, requestID)) {
+                    wipe(clientID, requestID, std::move(payload));
+                    return Handled::Yes;
+                }
+                return Handled::Replied;
 
             case Message::DoMaskIndexEntries:
-                // doit! We expect DoMaskIndexEntries, doWipeURIs, DoWipeUnknowns and doWipeEmptyDatabase in succession
-                doMaskIndexEntries(clientID, requestID, std::move(payload));
-                return Handled::Yes;
+                if (isWipeEnabled(clientID, requestID)) {
+                    // doit! We expect DoMaskIndexEntries, doWipeURIs, DoWipeUnknowns and doWipeEmptyDatabase in
+                    // succession
+                    doMaskIndexEntries(clientID, requestID, std::move(payload));
+                    return Handled::Yes;
+                }
+                return Handled::Replied;
 
             case Message::DoWipeURIs:  // Do the wipe on our currentWipeState
-                doWipeURIs(clientID, requestID, std::move(payload));
-                return Handled::Yes;
+                if (isWipeEnabled(clientID, requestID)) {
+                    doWipeURIs(clientID, requestID, std::move(payload));
+                    return Handled::Yes;
+                }
+                return Handled::Replied;
 
             case Message::DoWipeFinish:  // Finish wipe by deleting empty DBs
-                doWipeEmptyDatabase(clientID, requestID, std::move(payload));
-                return Handled::Yes;
+                if (isWipeEnabled(clientID, requestID)) {
+                    doWipeEmptyDatabase(clientID, requestID, std::move(payload));
+                    return Handled::Yes;
+                }
+                return Handled::Replied;
 
             case Message::DoWipeUnknowns:  // Wipe a set of unknown URIs
-                doWipeUnknowns(clientID, requestID, std::move(payload));
-                return Handled::Yes;
+                if (isWipeEnabled(clientID, requestID)) {
+                    doWipeUnknowns(clientID, requestID, std::move(payload));
+                    return Handled::Yes;
+                }
+                return Handled::Replied;
 
             case Message::DoUnsafeFullWipe:  // wipe a full database including its content
-                doUnsafeFullWipe(clientID, requestID, std::move(payload));
+                if (isWipeEnabled(clientID, requestID)) {
+                    doUnsafeFullWipe(clientID, requestID, std::move(payload));
+                    return Handled::Replied;
+                }
                 return Handled::Replied;
 
             default: {
@@ -176,6 +214,18 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
 }
 
 
+bool CatalogueHandler::isWipeEnabled(uint32_t clientID, uint32_t requestID) {
+    if (controlIdentifiers_.enabled(ControlIdentifier::Wipe)) {
+        return true;
+    }
+
+    std::ostringstream ss;
+    ss << "Client " << clientID << " attempted to wipe a catalogue, but this is disabled for their connection.";
+    Log::status() << ss.str() << std::endl;
+    Log::error() << ss.str() << std::endl;
+    error(ss.str(), clientID, requestID);
+    return false;
+}
 // API forwarding logic, adapted from original remoteHandler
 // Used for Inspect and List
 // ***************************************************************************************
@@ -378,32 +428,15 @@ void CatalogueHandler::schema(uint32_t clientID, uint32_t requestID, eckit::Buff
 
 void CatalogueHandler::stores(uint32_t clientID, uint32_t requestID) {
 
-    eckit::net::IPAddress clientIPaddress{controlSocket_.remoteAddr()};
-
-    std::string clientNetwork = "";
-    if (config_.has("networks")) {
-        for (const auto& net : config_.getSubConfigurations("networks")) {
-            if (net.has("name") && net.has("netmask")) {
-                eckit::net::NetMask netmask{net.getString("netmask")};
-                if (netmask.contains(clientIPaddress)) {
-                    clientNetwork = net.getString("name");
-                    break;
-                }
-            }
-        }
-    }
-
-    LOG_DEBUG_LIB(LibFdb5) << "Client " << clientIPaddress << " from network '" << clientNetwork << "'" << std::endl;
-
     ASSERT(config_.has("stores"));
     std::map<std::string, std::vector<eckit::net::Endpoint>> stores;
     for (const auto& configStore : config_.getSubConfigurations("stores")) {
         ASSERT(configStore.has("default"));
         eckit::net::Endpoint fieldLocationEndpoint{configStore.getString("default")};
         eckit::net::Endpoint storeEndpoint{fieldLocationEndpoint};
-        if (!clientNetwork.empty()) {
-            if (configStore.has(clientNetwork)) {
-                storeEndpoint = eckit::net::Endpoint{configStore.getString(clientNetwork)};
+        if (!clientNetwork_.empty()) {
+            if (configStore.has(clientNetwork_)) {
+                storeEndpoint = eckit::net::Endpoint{configStore.getString(clientNetwork_)};
             }
         }
 

--- a/src/fdb5/remote/server/CatalogueHandler.cc
+++ b/src/fdb5/remote/server/CatalogueHandler.cc
@@ -151,48 +151,36 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 return Handled::Replied;
 
             case Message::Wipe:  // Initial wipe request
-                if (isWipeEnabled(clientID, requestID)) {
-                    wipe(clientID, requestID, std::move(payload));
-                    return Handled::Yes;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                wipe(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             case Message::DoMaskIndexEntries:
-                if (isWipeEnabled(clientID, requestID)) {
-                    // doit! We expect DoMaskIndexEntries, doWipeURIs, DoWipeUnknowns and doWipeEmptyDatabase in
-                    // succession
-                    doMaskIndexEntries(clientID, requestID, std::move(payload));
-                    return Handled::Yes;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                // doit! We expect DoMaskIndexEntries, doWipeURIs, DoWipeUnknowns and doWipeEmptyDatabase in
+                // succession
+                doMaskIndexEntries(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             case Message::DoWipeURIs:  // Do the wipe on our currentWipeState
-                if (isWipeEnabled(clientID, requestID)) {
-                    doWipeURIs(clientID, requestID, std::move(payload));
-                    return Handled::Yes;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                doWipeURIs(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             case Message::DoWipeFinish:  // Finish wipe by deleting empty DBs
-                if (isWipeEnabled(clientID, requestID)) {
-                    doWipeEmptyDatabase(clientID, requestID, std::move(payload));
-                    return Handled::Yes;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                doWipeEmptyDatabase(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             case Message::DoWipeUnknowns:  // Wipe a set of unknown URIs
-                if (isWipeEnabled(clientID, requestID)) {
-                    doWipeUnknowns(clientID, requestID, std::move(payload));
-                    return Handled::Yes;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                doWipeUnknowns(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             case Message::DoUnsafeFullWipe:  // wipe a full database including its content
-                if (isWipeEnabled(clientID, requestID)) {
-                    doUnsafeFullWipe(clientID, requestID, std::move(payload));
-                    return Handled::Replied;
-                }
-                return Handled::Replied;
+                checkIsEnabled(ControlIdentifier::Wipe);
+                doUnsafeFullWipe(clientID, requestID, std::move(payload));
+                return Handled::Yes;
 
             default: {
                 std::ostringstream ss;
@@ -202,6 +190,13 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 throw SeriousBug(ss.str(), Here());
             }
         }
+    }
+    catch (UnhandledOperationException& e) {
+        std::ostringstream ss;
+        ss << "ERROR: Operation " << e.controlIdentifier() << " is not enabled for client " << clientID;
+        Log::status() << ss.str() << std::endl;
+        Log::error() << ss.str() << std::endl;
+        error(ss.str(), clientID, requestID);
     }
     catch (std::exception& e) {
         // n.b. more general than eckit::Exception
@@ -214,17 +209,10 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
 }
 
 
-bool CatalogueHandler::isWipeEnabled(uint32_t clientID, uint32_t requestID) {
-    if (controlIdentifiers_.enabled(ControlIdentifier::Wipe)) {
-        return true;
+void CatalogueHandler::checkIsEnabled(ControlIdentifier identifier) {
+    if (!controlIdentifiers_.enabled(identifier)) {
+        throw UnhandledOperationException(identifier);
     }
-
-    std::ostringstream ss;
-    ss << "Client " << clientID << " attempted to wipe a catalogue, but this is disabled for their connection.";
-    Log::status() << ss.str() << std::endl;
-    Log::error() << ss.str() << std::endl;
-    error(ss.str(), clientID, requestID);
-    return false;
 }
 // API forwarding logic, adapted from original remoteHandler
 // Used for Inspect and List
@@ -393,6 +381,7 @@ void CatalogueHandler::axes(uint32_t clientID, uint32_t requestID, eckit::Buffer
 }
 
 void CatalogueHandler::wipe(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+    checkIsEnabled(ControlIdentifier::Wipe);
     handleApiCall<WipeHelper>(clientID, requestID, std::move(payload));
 }
 

--- a/src/fdb5/remote/server/CatalogueHandler.cc
+++ b/src/fdb5/remote/server/CatalogueHandler.cc
@@ -56,7 +56,7 @@ CatalogueHandler::CatalogueHandler(eckit::net::TCPSocket& socket, const Config& 
                 eckit::net::NetMask netmask{net.getString("netmask")};
                 if (netmask.contains(clientIPaddress)) {
                     clientNetwork_ = net.getString("name");
-                    controlIdentifiers_ = ControlIdentifiers(net);
+                    controlIdentifiers_ = ControlIdentifiers::parse(net, false);
                     break;
                 }
             }
@@ -77,7 +77,7 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 std::lock_guard<std::mutex> lock(handlerMutex_);
                 auto it = fdbs_.find(clientID);
                 if (it == fdbs_.end()) {
-                    fdbs_[clientID];
+                    fdbs_.emplace(clientID, innerConfig_);
                     fdbControlConnection_ = true;
                     fdbDataConnection_ = !single_;
                     numControlConnection_++;
@@ -105,6 +105,13 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 throw SeriousBug(ss.str(), Here());
             }
         }
+    }
+    catch (UnauthorisedException& e) {
+        std::ostringstream ss;
+        ss << "ERROR: Operation " << e.controlIdentifier() << " is not enabled for client " << clientID;
+        Log::status() << ss.str() << std::endl;
+        Log::error() << ss.str() << std::endl;
+        error(ss.str(), clientID, requestID);
     }
     catch (std::exception& e) {
         // n.b. more general than eckit::Exception
@@ -151,34 +158,34 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
                 return Handled::Replied;
 
             case Message::Wipe:  // Initial wipe request
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 wipe(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
             case Message::DoMaskIndexEntries:
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 // doit! We expect DoMaskIndexEntries, doWipeURIs, DoWipeUnknowns and doWipeEmptyDatabase in
                 // succession
                 doMaskIndexEntries(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
             case Message::DoWipeURIs:  // Do the wipe on our currentWipeState
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 doWipeURIs(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
             case Message::DoWipeFinish:  // Finish wipe by deleting empty DBs
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 doWipeEmptyDatabase(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
             case Message::DoWipeUnknowns:  // Wipe a set of unknown URIs
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 doWipeUnknowns(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
             case Message::DoUnsafeFullWipe:  // wipe a full database including its content
-                checkIsEnabled(ControlIdentifier::Wipe);
+                isEnabled(ControlIdentifier::Wipe);
                 doUnsafeFullWipe(clientID, requestID, std::move(payload));
                 return Handled::Yes;
 
@@ -191,7 +198,7 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
             }
         }
     }
-    catch (UnhandledOperationException& e) {
+    catch (UnauthorisedException& e) {
         std::ostringstream ss;
         ss << "ERROR: Operation " << e.controlIdentifier() << " is not enabled for client " << clientID;
         Log::status() << ss.str() << std::endl;
@@ -208,12 +215,6 @@ Handled CatalogueHandler::handleControl(Message message, uint32_t clientID, uint
     return Handled::No;
 }
 
-
-void CatalogueHandler::checkIsEnabled(ControlIdentifier identifier) {
-    if (!controlIdentifiers_.enabled(identifier)) {
-        throw UnhandledOperationException(identifier);
-    }
-}
 // API forwarding logic, adapted from original remoteHandler
 // Used for Inspect and List
 // ***************************************************************************************
@@ -287,8 +288,11 @@ struct WipeHelper : public BaseHelper<CatalogueWipeState> {
             // Expect this dbKey not to already be in progress
             ASSERT(handler.wipesInProgress_.find(dbKey) == handler.wipesInProgress_.end());
 
+            if (unsafeWipeAll_) {
+                handler.isEnabled(ControlIdentifier::UnsafeWipeAll);
+            }
             handler.wipesInProgress_[dbKey] = {
-                unsafeWipeAll_, CatalogueReaderFactory::instance().build(dbKey, handler.config_),
+                unsafeWipeAll_, CatalogueReaderFactory::instance().build(dbKey, handler.innerConfig_),
                 CatalogueWipeState(dbKey, state.safeURIs(), state.deleteMap(), state.indexesToMask())};
         }
         else {
@@ -303,8 +307,6 @@ struct WipeHelper : public BaseHelper<CatalogueWipeState> {
     }
 
     WipeStateIterator apiCall(FDB& fdb, const FDBToolRequest& request) const {
-        // XXX: I'm inclined to say that in a multi-server scenario, unsafe wipe all is a bad idea.
-        ASSERT(!unsafeWipeAll_);
         return fdb.internal_->wipe(request, doit_, false, unsafeWipeAll_);
     }
 
@@ -338,7 +340,7 @@ void CatalogueHandler::handleApiCall(uint32_t clientID, uint32_t requestID, ecki
         std::lock_guard<std::mutex> lock(fdbMutex_);
         auto it = fdbs_.find(clientID);
         if (it == fdbs_.end()) {
-            fdbs_[clientID];
+            fdbs_.emplace(clientID, innerConfig_);
         }
     }
 
@@ -373,23 +375,27 @@ void CatalogueHandler::handleApiCall(uint32_t clientID, uint32_t requestID, ecki
 }
 
 void CatalogueHandler::list(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+    isEnabled(ControlIdentifier::List);
     handleApiCall<ListHelper>(clientID, requestID, std::move(payload));
 }
 
 void CatalogueHandler::axes(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+    isEnabled(ControlIdentifier::List);
     handleApiCall<AxesHelper>(clientID, requestID, std::move(payload));
 }
 
 void CatalogueHandler::wipe(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
-    checkIsEnabled(ControlIdentifier::Wipe);
+    isEnabled(ControlIdentifier::Wipe);
     handleApiCall<WipeHelper>(clientID, requestID, std::move(payload));
 }
 
 void CatalogueHandler::inspect(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+    isEnabled(ControlIdentifier::Retrieve);
     handleApiCall<InspectHelper>(clientID, requestID, std::move(payload));
 }
 
 void CatalogueHandler::stats(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+    isEnabled(ControlIdentifier::List);
     handleApiCall<StatsHelper>(clientID, requestID, std::move(payload));
 }
 
@@ -399,7 +405,7 @@ void CatalogueHandler::schema(uint32_t clientID, uint32_t requestID, eckit::Buff
     eckit::MemoryStream stream(schemaBuffer);
 
     if (payload.size() == 0) {  // client requesting the top-level schema
-        stream << config_.schema();
+        stream << innerConfig_.schema();
     }
     else {
         // 1. Read dbkey to select catalogue
@@ -408,6 +414,7 @@ void CatalogueHandler::schema(uint32_t clientID, uint32_t requestID, eckit::Buff
 
         // 2. Get catalogue
         Catalogue& cat = catalogue(clientID, dbKey);
+        cat.controlIdentifiers().enabled(ControlIdentifier::List);
         const Schema& schema = cat.schema();
         stream << schema;
     }
@@ -472,7 +479,7 @@ void CatalogueHandler::exists(uint32_t clientID, uint32_t requestID, eckit::Buff
     {
         eckit::MemoryStream stream(payload);
         const Key dbKey(stream);
-        exists = CatalogueReaderFactory::instance().build(dbKey, config_)->exists();
+        exists = CatalogueReaderFactory::instance().build(dbKey, innerConfig_)->exists();
     }
 
     eckit::Buffer existBuf(5);
@@ -483,6 +490,8 @@ void CatalogueHandler::exists(uint32_t clientID, uint32_t requestID, eckit::Buff
 }
 
 void CatalogueHandler::flush(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) {
+
+    isEnabled(ControlIdentifier::Archive);
 
     ASSERT(payload.size() > 0);
 
@@ -601,7 +610,7 @@ CatalogueWriter& CatalogueHandler::catalogue(uint32_t id, const Key& dbKey) {
     if (!single_) {
         numDataConnection_++;
     }
-    return *((catalogues_.emplace(id, CatalogueArchiver(!single_, dbKey, config_)).first)->second.catalogue);
+    return *((catalogues_.emplace(id, CatalogueArchiver(!single_, dbKey, innerConfig_)).first)->second.catalogue);
 }
 
 const CatalogueHandler::WipeInProgress& CatalogueHandler::cachedWipeState(Key dbKey) const {

--- a/src/fdb5/remote/server/CatalogueHandler.h
+++ b/src/fdb5/remote/server/CatalogueHandler.h
@@ -59,6 +59,8 @@ private:  // methods
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID) override;
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) override;
 
+    bool isWipeEnabled(uint32_t clientID, uint32_t requestID);
+
     // API functionality
     template <typename HelperClass>
     void handleApiCall(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload);
@@ -100,6 +102,9 @@ private:  // member
 
     bool fdbControlConnection_;
     bool fdbDataConnection_;
+
+    std::string clientNetwork_;
+    ControlIdentifiers controlIdentifiers_;
 
     struct WipeInProgress {
         bool unsafeWipeAll = false;

--- a/src/fdb5/remote/server/CatalogueHandler.h
+++ b/src/fdb5/remote/server/CatalogueHandler.h
@@ -59,7 +59,7 @@ private:  // methods
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID) override;
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) override;
 
-    bool isWipeEnabled(uint32_t clientID, uint32_t requestID);
+    void checkIsEnabled(ControlIdentifier identifier);
 
     // API functionality
     template <typename HelperClass>

--- a/src/fdb5/remote/server/CatalogueHandler.h
+++ b/src/fdb5/remote/server/CatalogueHandler.h
@@ -56,10 +56,10 @@ public:  // methods
 
 private:  // methods
 
+    friend struct WipeHelper;
+
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID) override;
     Handled handleControl(Message message, uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload) override;
-
-    void checkIsEnabled(ControlIdentifier identifier);
 
     // API functionality
     template <typename HelperClass>
@@ -87,8 +87,6 @@ private:  // methods
     void doWipeEmptyDatabase(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload);
     void doUnsafeFullWipe(uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload);
 
-    const Config& config() const { return config_; }
-
     const WipeInProgress& cachedWipeState(Key dbKey) const;
 
 private:  // member
@@ -104,7 +102,6 @@ private:  // member
     bool fdbDataConnection_;
 
     std::string clientNetwork_;
-    ControlIdentifiers controlIdentifiers_;
 
     struct WipeInProgress {
         bool unsafeWipeAll = false;

--- a/src/fdb5/remote/server/ServerConnection.cc
+++ b/src/fdb5/remote/server/ServerConnection.cc
@@ -72,6 +72,7 @@ ServerConnection::ServerConnection(eckit::net::TCPSocket& socket, const Config& 
     archiveQueue_(eckit::Resource<size_t>("fdbServerMaxQueueSize", defaultArchiveQueueSize)),
     controlSocket_(socket) {
 
+    innerConfig_ = config_.has("fdb") ? Config{config_.getSubConfiguration("fdb"), config_.userConfig()} : config_;
     LOG_DEBUG_LIB(LibFdb5) << "ServerConnection::ServerConnection initialized" << std::endl;
 }
 
@@ -515,6 +516,12 @@ void ServerConnection::waitForWorkers() {
     std::lock_guard<std::mutex> lock(readLocationMutex_);
     if (readLocationWorker_.joinable()) {
         readLocationWorker_.join();
+    }
+}
+
+void ServerConnection::isEnabled(ControlIdentifier identifier) {
+    if (!controlIdentifiers_.enabled(identifier)) {
+        throw UnauthorisedException(identifier);
     }
 }
 

--- a/src/fdb5/remote/server/ServerConnection.h
+++ b/src/fdb5/remote/server/ServerConnection.h
@@ -21,12 +21,14 @@
 #include <mutex>
 
 #include "eckit/container/Queue.h"
+#include "eckit/exception/Exceptions.h"
 #include "eckit/io/Buffer.h"
 #include "eckit/io/DataHandle.h"
 #include "eckit/net/TCPServer.h"
 #include "eckit/net/TCPSocket.h"
 #include "eckit/runtime/SessionID.h"
 
+#include "fdb5/api/helpers/ControlIterator.h"
 #include "fdb5/config/Config.h"
 #include "fdb5/remote/Connection.h"
 #include "fdb5/remote/Messages.h"
@@ -42,6 +44,19 @@ enum class Handled {
     YesAddReadListener,
     YesRemoveReadListener,
     Replied,
+};
+
+class UnhandledOperationException : public eckit::Exception {
+public:
+
+    UnhandledOperationException(ControlIdentifier ci) :
+        eckit::Exception("UnhandledOperationException: " + std::to_string(static_cast<int>(ci))), ci_(ci) {}
+
+    ControlIdentifier controlIdentifier() const { return ci_; }
+
+private:
+
+    ControlIdentifier ci_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/server/ServerConnection.h
+++ b/src/fdb5/remote/server/ServerConnection.h
@@ -46,11 +46,11 @@ enum class Handled {
     Replied,
 };
 
-class UnhandledOperationException : public eckit::Exception {
+class UnauthorisedException : public eckit::Exception {
 public:
 
-    UnhandledOperationException(ControlIdentifier ci) :
-        eckit::Exception("UnhandledOperationException: " + std::to_string(static_cast<int>(ci))), ci_(ci) {}
+    UnauthorisedException(ControlIdentifier ci) :
+        eckit::Exception("UnauthorisedException: " + std::to_string(static_cast<int>(ci))), ci_(ci) {}
 
     ControlIdentifier controlIdentifier() const { return ci_; }
 
@@ -136,6 +136,8 @@ protected:
     void archiver();
     void queue(Message message, uint32_t clientID, uint32_t requestID, eckit::Buffer&& payload);
 
+    void isEnabled(ControlIdentifier identifier);
+
     void handleException(std::exception_ptr e) override;
 
 private:
@@ -154,6 +156,10 @@ protected:
     virtual bool remove(bool control, uint32_t clientID) = 0;
 
     Config config_;
+    Config innerConfig_;
+
+    ControlIdentifiers controlIdentifiers_;
+
     std::string dataListenHostname_;
 
     eckit::Queue<readLocationElem> readLocationQueue_;

--- a/src/fdb5/remote/server/StoreHandler.cc
+++ b/src/fdb5/remote/server/StoreHandler.cc
@@ -315,7 +315,7 @@ Store& StoreHandler::store(uint32_t clientID, const Key& dbKey) {
     if (!single_) {
         numDataConnection_++;
     }
-    return *((stores_.emplace(clientID, StoreHelper(!single_, dbKey, config_)).first)->second.store);
+    return *((stores_.emplace(clientID, StoreHelper(!single_, dbKey, innerConfig_)).first)->second.store);
 }
 
 Store& StoreHandler::getStore(uint32_t clientID, const eckit::URI& uri) {
@@ -330,7 +330,7 @@ Store& StoreHandler::getStore(uint32_t clientID, const eckit::URI& uri) {
     if (!single_) {
         numDataConnection_++;
     }
-    return *((stores_.emplace(clientID, StoreHelper(!single_, uri, config_)).first)->second.store);
+    return *((stores_.emplace(clientID, StoreHelper(!single_, uri, innerConfig_)).first)->second.store);
 }
 
 void StoreHandler::exists(const uint32_t clientID, const uint32_t requestID, const eckit::Buffer& payload) const {
@@ -342,7 +342,7 @@ void StoreHandler::exists(const uint32_t clientID, const uint32_t requestID, con
     {
         eckit::MemoryStream stream(payload);
         const Key dbKey(stream);
-        exists = StoreFactory::instance().build(dbKey, config_)->exists();
+        exists = StoreFactory::instance().build(dbKey, innerConfig_)->exists();
     }
 
     eckit::Buffer existBuf(5);

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -53,6 +53,7 @@ constexpr const char* archive_lock_file = "archive.lock";
 constexpr const char* list_lock_file = "list.lock";
 constexpr const char* wipe_lock_file = "wipe.lock";
 constexpr const char* allow_duplicates_file = "duplicates.allow";
+constexpr const char* unsafe_wipe_lock_file = "unsafe_wipe.lock";
 }  // namespace
 
 const std::map<ControlIdentifier, const char*> controlfile_lookup{
@@ -60,7 +61,8 @@ const std::map<ControlIdentifier, const char*> controlfile_lookup{
     {ControlIdentifier::Archive, archive_lock_file},
     {ControlIdentifier::List, list_lock_file},
     {ControlIdentifier::Wipe, wipe_lock_file},
-    {ControlIdentifier::UniqueRoot, allow_duplicates_file}};
+    {ControlIdentifier::UniqueRoot, allow_duplicates_file},
+    {ControlIdentifier::UnsafeWipeAll, unsafe_wipe_lock_file}};
 
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

add ControlIdentifier to the remote FDB networs (to prevent specific operations from selected networks) 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-267
<!-- PREVIEW-PUBLISH-FDB_END -->