### PR TITLE
Fix incorrect data retrieval is special cases

### DIFF
--- a/src/chunked_data_view/Axis.cc
+++ b/src/chunked_data_view/Axis.cc
@@ -82,5 +82,4 @@ size_t Axis::index(const fdb5::Key& key) const {
     return index;
 }
 
-
 }  // namespace chunked_data_view

--- a/src/chunked_data_view/ChunkedDataViewImpl.cc
+++ b/src/chunked_data_view/ChunkedDataViewImpl.cc
@@ -20,6 +20,24 @@
 
 namespace chunked_data_view {
 
+namespace {
+
+size_t countFieldsForPart(const ViewPart& part, const std::vector<size_t>& chunkShape,
+                          const size_t extensionAxisIndex) {
+    size_t result = 1;
+    for (size_t i = 0; i < chunkShape.size() - 1; ++i) {
+        if (i == extensionAxisIndex) {
+            result *= part.shape()[i];
+        }
+        else {
+            result *= chunkShape[i];
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
 ChunkedDataViewImpl::ChunkedDataViewImpl(std::vector<ViewPart> parts, size_t extensionAxisIndex) :
     parts_(std::move(parts)), extensionAxisIndex_(extensionAxisIndex) {
     shape_ = parts_[0].shape();
@@ -75,10 +93,28 @@ void ChunkedDataViewImpl::at(const std::vector<size_t>& chunkIndex, float* ptr, 
         }
     }
 
+    if (!parts_[0].isAxisChunked(extensionAxisIndex_)) {
+        // NoChunking: single chunk spans all parts on the extension axis.
+        // Each part writes directly into the combined buffer. The extension axis
+        // parameters tell computeBufferIndex to use the combined size for strides
+        // and offset each part's indices on the extension axis.
+        size_t totalExtSize = shape_[extensionAxisIndex_];
+        size_t extOffset = 0;
+
+        for (const auto& part : parts_) {
+            size_t partFields = countFieldsForPart(part, chunkShape_, extensionAxisIndex_);
+
+            part.at(chunkIndex, ptr, len, partFields, extensionAxisIndex_, totalExtSize, extOffset);
+
+            extOffset += part.shape()[extensionAxisIndex_];
+        }
+        return;
+    }
+
+    // IndividualChunking: route to the single part that owns this chunk index
     auto idx(chunkIndex);
 
     for (const auto& part : parts_) {
-        // Skip parts which the index isn't part of
         if (idx[extensionAxisIndex_] >= part.shape()[extensionAxisIndex_]) {
             idx[extensionAxisIndex_] -= part.shape()[extensionAxisIndex_];
             continue;
@@ -86,6 +122,7 @@ void ChunkedDataViewImpl::at(const std::vector<size_t>& chunkIndex, float* ptr, 
         part.at(idx, ptr, len, countFields());
         return;
     }
+    throw eckit::SeriousBug("ChunkedDataViewImpl::at - This code should never be reached.");
 }
 
 }  // namespace chunked_data_view

--- a/src/chunked_data_view/ChunkedDataViewImpl.h
+++ b/src/chunked_data_view/ChunkedDataViewImpl.h
@@ -50,6 +50,7 @@ public:
         return result;
     }
 
+
 private:
 
     std::vector<size_t> chunkShape_{};

--- a/src/chunked_data_view/GribExtractor.cc
+++ b/src/chunked_data_view/GribExtractor.cc
@@ -15,13 +15,10 @@
 #include "chunked_data_view/ListIterator.h"
 
 #include "eckit/exception/Exceptions.h"
-#include "eckit/log/Log.h"
 #include "eckit/message/Reader.h"
 #include "fdb5/database/Key.h"
 
-#include <algorithm>
 #include <cstddef>
-#include <exception>
 #include <memory>
 #include <ostream>
 #include <sstream>
@@ -39,7 +36,8 @@ DataLayout GribExtractor::layout(eckit::DataHandle& handle) const {
     return {countValues, 4};
 }
 
-size_t computeBufferIndex(const std::vector<Axis>& axes, const fdb5::Key& key) {
+size_t computeBufferIndex(const std::vector<Axis>& axes, const fdb5::Key& key, size_t extensionAxisIdx,
+                          size_t combinedExtSize = 0, size_t extensionOffset = 0) {
     std::vector<size_t> result;
     result.reserve(axes.size());
 
@@ -55,15 +53,17 @@ size_t computeBufferIndex(const std::vector<Axis>& axes, const fdb5::Key& key) {
 
     ASSERT(result.size() == axes.size());
 
-    return chunked_data_view::index_mapping::axis_index_to_buffer_index(result, axes);
+    return chunked_data_view::index_mapping::axis_index_to_buffer_index(result, axes, extensionAxisIdx, combinedExtSize,
+                                                                        extensionOffset);
 }
 
-void GribExtractor::writeInto(const metkit::mars::MarsRequest& request,
-                              std::unique_ptr<ListIteratorInterface> list_iterator, const std::vector<Axis>& axes,
-                              const DataLayout& layout, float* ptr, size_t len, size_t expected_msg_count) const {
+size_t GribExtractor::writeInto(const metkit::mars::MarsRequest& request,
+                                std::unique_ptr<ListIteratorInterface> list_iterator, const std::vector<Axis>& axes,
+                                const DataLayout& layout, float* ptr, size_t len, size_t extensionAxisIdx,
+                                size_t combinedExtSize, size_t extensionOffset) const {
 
     bool iterator_empty = true;
-    std::vector<bool> bitset(expected_msg_count);
+    size_t messagesWritten = 0;
 
     while (auto res = list_iterator->next()) {
 
@@ -74,30 +74,25 @@ void GribExtractor::writeInto(const metkit::mars::MarsRequest& request,
 
         const auto& key = std::get<0>(*res);
         auto& data_handle = std::get<1>(*res);
-        const size_t msgIndex = computeBufferIndex(axes, key);
+        const size_t msgIndex = computeBufferIndex(axes, key, extensionAxisIdx, combinedExtSize, extensionOffset);
 
-        try {
-            eckit::message::Reader reader(*data_handle);
-            eckit::message::Message msg{};
+        eckit::message::Reader reader(*data_handle);
+        eckit::message::Message msg{};
 
-            auto copyInto = ptr + msgIndex * layout.countValues;
-            const auto end = copyInto + layout.countValues;
-            ASSERT(end - ptr <= len);
+        auto copyInto = ptr + msgIndex * layout.countValues;
+        const auto end = copyInto + layout.countValues;
+        ASSERT(end - ptr <= len);
 
-            while ((msg = reader.next())) {
-                if (const auto size = msg.getSize("values"); size != layout.countValues) {
-                    std::ostringstream ss;
-                    ss << "GribExractor: Unexpected field size found in GRIB message for key: " << key
-                       << " expected: " << layout.countValues << " found: " << size
-                       << ". All fields in your view need to be of equal size.";
-                    throw eckit::Exception(ss.str());
-                }
-                msg.getFloatArray("values", copyInto, layout.countValues);
-                bitset[msgIndex] = true;
+        while ((msg = reader.next())) {
+            if (const auto size = msg.getSize("values"); size != layout.countValues) {
+                std::ostringstream ss;
+                ss << "GribExractor: Unexpected field size found in GRIB message for key: " << key
+                   << " expected: " << layout.countValues << " found: " << size
+                   << ". All fields in your view need to be of equal size.";
+                throw eckit::Exception(ss.str());
             }
-        }
-        catch (const std::exception& e) {
-            eckit::Log::debug() << e.what() << std::endl;
+            msg.getFloatArray("values", copyInto, layout.countValues);
+            messagesWritten++;
         }
     }
 
@@ -107,12 +102,6 @@ void GribExtractor::writeInto(const metkit::mars::MarsRequest& request,
         throw eckit::Exception(ss.str());
     }
 
-    if (const auto read_count = std::count(std::begin(bitset), std::end(bitset), true); read_count != bitset.size()) {
-        std::ostringstream ss;
-        ss << "GribExtractor: retrieved only " << read_count << " of " << bitset.size() << " fields in request "
-           << request;
-
-        throw eckit::Exception(ss.str());
-    }
+    return messagesWritten;
 }
 };  // namespace chunked_data_view

--- a/src/chunked_data_view/GribExtractor.h
+++ b/src/chunked_data_view/GribExtractor.h
@@ -27,8 +27,8 @@ public:
 
     DataLayout layout(eckit::DataHandle& handle) const override;
 
-    void writeInto(const metkit::mars::MarsRequest& request, std::unique_ptr<ListIteratorInterface> list_iterator,
-                   const std::vector<Axis>& axes, const DataLayout& layout, float* ptr, size_t len,
-                   size_t expected_msg_count) const override;
+    size_t writeInto(const metkit::mars::MarsRequest& request, std::unique_ptr<ListIteratorInterface> list_iterator,
+                     const std::vector<Axis>& axes, const DataLayout& layout, float* ptr, size_t len,
+                     size_t extensionAxisIdx, size_t combinedExtSize, size_t extensionOffset) const override;
 };
 }  // namespace chunked_data_view

--- a/src/chunked_data_view/IndexMapper.cc
+++ b/src/chunked_data_view/IndexMapper.cc
@@ -28,7 +28,9 @@ namespace chunked_data_view {
  * @param axes the axes
  * @return index in the buffer (an offset)
  */
-size_t index_mapping::axis_index_to_buffer_index(const std::vector<size_t>& indices, const std::vector<Axis>& axes) {
+size_t index_mapping::axis_index_to_buffer_index(const std::vector<size_t>& indices, const std::vector<Axis>& axes,
+                                                 size_t extensionAxisIdx, size_t combinedExtSize,
+                                                 size_t extensionOffset) {
 
     ASSERT(indices.size() == axes.size());
 
@@ -38,8 +40,14 @@ size_t index_mapping::axis_index_to_buffer_index(const std::vector<size_t>& indi
     for (int i = axes.size() - 1; i >= 0; --i) {
 
         if (!axes[i].isChunked()) {
-            index += indices[i] * prod;
-            prod *= axes[i].size();
+            if (static_cast<size_t>(i) == extensionAxisIdx) {
+                index += (indices[i] + extensionOffset) * prod;
+                prod *= combinedExtSize;
+            }
+            else {
+                index += indices[i] * prod;
+                prod *= axes[i].size();
+            }
         }
     }
 

--- a/src/chunked_data_view/IndexMapper.h
+++ b/src/chunked_data_view/IndexMapper.h
@@ -16,6 +16,8 @@
 
 namespace chunked_data_view::index_mapping {
 
-size_t axis_index_to_buffer_index(const std::vector<size_t>& indices, const std::vector<Axis>& axes);
+size_t axis_index_to_buffer_index(const std::vector<size_t>& indices, const std::vector<Axis>& axes,
+                                  size_t extensionAxisIdx = SIZE_MAX, size_t combinedExtSize = 0,
+                                  size_t extensionOffset = 0);
 std::vector<size_t> to_axis_parameter_index(const size_t& index, const Axis& axis);
 }  // namespace chunked_data_view::index_mapping

--- a/src/chunked_data_view/ViewPart.cc
+++ b/src/chunked_data_view/ViewPart.cc
@@ -82,14 +82,22 @@ ViewPart::ViewPart(metkit::mars::MarsRequest request, std::unique_ptr<Extractor>
 }
 
 
-void ViewPart::at(const std::vector<size_t>& chunkIndex, float* ptr, size_t len, size_t expected_msg_count) const {
+void ViewPart::at(const std::vector<size_t>& chunkIndex, float* ptr, size_t len, size_t expected_msg_count,
+                  size_t extensionAxisIdx, size_t combinedExtSize, size_t extensionOffset) const {
     ASSERT(chunkIndex.size() - 1 == axes_.size());
     auto request = request_;
     for (size_t idx = 0; idx < chunkIndex.size() - 1; ++idx) {
         RequestManipulation::updateRequest(request, axes_[idx], chunkIndex[idx]);
     }
     auto listIterator = fdb_->inspect(request);
-    extractor_->writeInto(request, std::move(listIterator), axes_, layout_, ptr, len, expected_msg_count);
+    size_t written = extractor_->writeInto(request, std::move(listIterator), axes_, layout_, ptr, len, extensionAxisIdx,
+                                           combinedExtSize, extensionOffset);
+    if (written != expected_msg_count) {
+        std::ostringstream ss;
+        ss << "ViewPart::at: retrieved only " << written << " of " << expected_msg_count << " fields in request "
+           << request;
+        throw eckit::UserError(ss.str());
+    }
 }
 
 metkit::mars::MarsRequest ViewPart::requestAt(const std::vector<size_t>& chunkIndex) const {

--- a/src/chunked_data_view/ViewPart.h
+++ b/src/chunked_data_view/ViewPart.h
@@ -28,10 +28,11 @@ public:
 
     ViewPart(metkit::mars::MarsRequest request, std::unique_ptr<Extractor> extractor, std::shared_ptr<FdbInterface> fdb,
              const std::vector<AxisDefinition>& axes);
-    void at(const std::vector<size_t>& chunkIndex, float* ptr, size_t len, size_t expected_msg_count) const;
+    void at(const std::vector<size_t>& chunkIndex, float* ptr, size_t len, size_t expected_msg_count,
+            size_t extensionAxisIdx = SIZE_MAX, size_t combinedExtSize = 0, size_t extensionOffset = 0) const;
     std::vector<size_t> shape() const { return shape_; }
     const DataLayout& layout() const { return layout_; }
-    bool isAxisChunked(size_t index) { return axes_.at(index).isChunked(); };
+    bool isAxisChunked(size_t index) const { return axes_.at(index).isChunked(); };
 
     bool extensibleWith(const ViewPart& other, size_t extension_axis) const;
 

--- a/src/chunked_data_view/include/chunked_data_view/Extractor.h
+++ b/src/chunked_data_view/include/chunked_data_view/Extractor.h
@@ -37,17 +37,21 @@ public:
     virtual DataLayout layout(eckit::DataHandle& handle) const = 0;
 
     /// Writes the extracted data into the out pointer.
-    /// The caller must ensure there is enought memory allccated for all values to be copied into out.
+    /// The caller must ensure there is enough memory allocated for all values to be copied into out.
     /// @param request that was used to read data from FDB, only used to enhance error messages
     /// @param list_iterator to read data from
     /// @param axes of the corresponding view.
     /// @param layout of the expected field.
-    /// @param out pointer to write into.
-    /// @param out len of memory pointed to by ptr in floats
-    /// @param expected_msg_count number of GRIB messages expected
-    virtual void writeInto(const metkit::mars::MarsRequest& request,
-                           std::unique_ptr<ListIteratorInterface> list_iterator, const std::vector<Axis>& axes,
-                           const DataLayout& layout, float* ptr, size_t len, size_t expected_msg_count) const = 0;
+    /// @param ptr pointer to write into.
+    /// @param len of memory pointed to by ptr in floats
+    /// @param extensionAxisIdx index of the extension axis (SIZE_MAX = no extension)
+    /// @param combinedExtSize combined size of the extension axis across all parts
+    /// @param extensionOffset offset of this part on the extension axis
+    /// @return number of messages written
+    virtual size_t writeInto(const metkit::mars::MarsRequest& request,
+                             std::unique_ptr<ListIteratorInterface> list_iterator, const std::vector<Axis>& axes,
+                             const DataLayout& layout, float* ptr, size_t len, size_t extensionAxisIdx = SIZE_MAX,
+                             size_t combinedExtSize = 0, size_t extensionOffset = 0) const = 0;
 };
 
 enum class ExtractorType {

--- a/tests/chunked_data_view/test_axis.cc
+++ b/tests/chunked_data_view/test_axis.cc
@@ -101,11 +101,7 @@ CASE("RequestManipulation | Axis test multiple axis for Indices | Can create a s
 }
 
 
-bool assert_arrays(
-    const metkit::mars::MarsRequest& request,
-    const chunked_data_view::Axis&
-        axis) {  // chunked_data_view::Axis::Parameter first, chunked_data_view::Axis::Parameter second,
-                 // chunked_data_view::Axis::Parameter third, chunked_data_view::Axis::Parameter fourth) {
+bool assert_arrays(const metkit::mars::MarsRequest& request, const chunked_data_view::Axis& axis) {
 
     EXPECT_EQUAL(axis.parameters().size(), 4);
 

--- a/tests/chunked_data_view/test_builder.cc
+++ b/tests/chunked_data_view/test_builder.cc
@@ -73,11 +73,13 @@ struct FakeExtractor : public cdv::Extractor {
         return layout;
     }
 
-    void writeInto(const metkit::mars::MarsRequest& request,
-                   std::unique_ptr<chunked_data_view::ListIteratorInterface> list_iterator,
-                   const std::vector<chunked_data_view::Axis>& axes, const chunked_data_view::DataLayout& layout,
-                   float* ptr, size_t len, size_t expected_msg_count) const override {
+    size_t writeInto(const metkit::mars::MarsRequest& request,
+                     std::unique_ptr<chunked_data_view::ListIteratorInterface> list_iterator,
+                     const std::vector<chunked_data_view::Axis>& axes, const chunked_data_view::DataLayout& layout,
+                     float* ptr, size_t len, size_t extensionAxisIdx, size_t combinedExtSize,
+                     size_t extensionOffset) const override {
         cdv::DataLayout readLayout{};
+        size_t count = 0;
         while (auto res = list_iterator->next()) {
             if (!res) {
                 break;
@@ -87,10 +89,12 @@ struct FakeExtractor : public cdv::Extractor {
             data_handle->openForRead();
 
             EXPECT_EQUAL(data_handle->read(&readLayout.countValues, sizeof(layout.countValues)), 8l);
-            EXPECT_EQUAL(data_handle->read(&readLayout.bytesPerValue, sizeof(layout.bytesPerValue)), 4l);
+            EXPECT_EQUAL(data_handle->read(&readLayout.bytesPerValue, sizeof(layout.bytesPerValue)), 8l);
             const size_t totalBytes = layout.countValues * layout.bytesPerValue;
             EXPECT_EQUAL(data_handle->read(ptr, totalBytes), totalBytes);
+            count++;
         }
+        return count;
     };
 };
 

--- a/tests/chunked_data_view/test_index_mapper.cc
+++ b/tests/chunked_data_view/test_index_mapper.cc
@@ -88,6 +88,62 @@ CASE("index_mapping | 3 axes 2/1 param | Chunked/Non-Chunked| Valid access") {
 }
 
 
+CASE("index_mapping | axis_index_to_buffer_index | extension axis remaps stride and offset") {
+
+    // 3 unchunked axes: [A(size=3), B(size=2, extension), C(size=4)]
+    // Without extension: flat index = a * 2*4 + b * 4 + c = a*8 + b*4 + c
+    // With extension (combinedExtSize=5, offset=2):
+    //   flat index = a * 5*4 + (b+2) * 4 + c = a*20 + (b+2)*4 + c
+
+    std::vector<std::string> a_vals = {"a0", "a1", "a2"};
+    std::vector<std::string> b_vals = {"b0", "b1"};
+    std::vector<std::string> c_vals = {"c0", "c1", "c2", "c3"};
+
+    chunked_data_view::Parameter a_param = {"a", a_vals};
+    chunked_data_view::Parameter b_param = {"b", b_vals};
+    chunked_data_view::Parameter c_param = {"c", c_vals};
+
+    const std::vector<chunked_data_view::Axis> axes = {{{a_param}, false}, {{b_param}, false}, {{c_param}, false}};
+
+    // Without extension params: a=1, b=1, c=2 → 1*8 + 1*4 + 2 = 14
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({1, 1, 2}, axes), 14);
+
+    // With extension on axis 1 (combinedExtSize=5, offset=2):
+    // a=1, b=1, c=2 → 1*20 + (1+2)*4 + 2 = 20 + 12 + 2 = 34
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({1, 1, 2}, axes, 1, 5, 2), 34);
+
+    // a=0, b=0, c=0 with offset=2 → 0*20 + (0+2)*4 + 0 = 8
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({0, 0, 0}, axes, 1, 5, 2), 8);
+
+    // a=0, b=0, c=0 with offset=0 → 0 (same as no extension)
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({0, 0, 0}, axes, 1, 5, 0), 0);
+}
+
+CASE("index_mapping | axis_index_to_buffer_index | extension axis with chunked neighbours") {
+
+    // Axes: [A(chunked), B(unchunked, size=3, extension), C(unchunked, size=4)]
+    // Chunked axes are skipped in index computation.
+    // Without extension: flat = b * 4 + c
+    // With extension (combinedExtSize=7, offset=3): flat = (b+3) * 4 + c
+
+    std::vector<std::string> a_vals = {"a0", "a1"};
+    std::vector<std::string> b_vals = {"b0", "b1", "b2"};
+    std::vector<std::string> c_vals = {"c0", "c1", "c2", "c3"};
+
+    chunked_data_view::Parameter a_param = {"a", a_vals};
+    chunked_data_view::Parameter b_param = {"b", b_vals};
+    chunked_data_view::Parameter c_param = {"c", c_vals};
+
+    const std::vector<chunked_data_view::Axis> axes = {{{a_param}, true}, {{b_param}, false}, {{c_param}, false}};
+
+    // Without extension: a=0 (chunked, ignored), b=2, c=3 → 2*4 + 3 = 11
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({0, 2, 3}, axes), 11);
+
+    // With extension on axis 1 (combinedExtSize=7, offset=3):
+    // b=2, c=3 → (2+3)*4 + 3 = 23
+    EXPECT_EQUAL(chunked_data_view::index_mapping::axis_index_to_buffer_index({0, 2, 3}, axes, 1, 7, 3), 23);
+}
+
 int main(int argc, char** argv) {
     return ::eckit::testing::run_tests(argc, argv);
 }

--- a/tests/chunked_data_view/test_view.cc
+++ b/tests/chunked_data_view/test_view.cc
@@ -106,28 +106,19 @@ struct FakeExtractor : public cdv::Extractor {
         return layout;
     }
 
-    void writeInto(const metkit::mars::MarsRequest& request,
-                   std::unique_ptr<chunked_data_view::ListIteratorInterface> list_iterator,
-                   const std::vector<chunked_data_view::Axis>& axes, const chunked_data_view::DataLayout& layout,
-                   float* ptr, size_t len, size_t expected_msg_count) const override {
-        cdv::DataLayout readLayout{};
-
-
+    size_t writeInto(const metkit::mars::MarsRequest& request,
+                     std::unique_ptr<chunked_data_view::ListIteratorInterface> list_iterator,
+                     const std::vector<chunked_data_view::Axis>& axes, const chunked_data_view::DataLayout& layout,
+                     float* ptr, size_t len, size_t extensionAxisIdx, size_t combinedExtSize,
+                     size_t extensionOffset) const override {
+        size_t count = 0;
         while (auto res = list_iterator->next()) {
-
             if (!res) {
                 break;
             }
-
-            const auto& key = std::get<0>(*res);
-            auto& data_handle = std::get<1>(*res);
-            data_handle->openForRead();
-
-            EXPECT_EQUAL(data_handle->read(&readLayout.countValues, sizeof(layout.countValues)), 8l);
-            EXPECT_EQUAL(data_handle->read(&readLayout.bytesPerValue, sizeof(layout.bytesPerValue)), 4l);
-            const size_t totalBytes = layout.countValues * layout.bytesPerValue;
-            EXPECT_EQUAL(data_handle->read(ptr, totalBytes), totalBytes);
+            count++;
         }
+        return count;
     };
 };
 
@@ -201,6 +192,52 @@ CASE("ChunkedDataView | View from 2 requests | Can compute shape") {
             .build();
     // Expect to get: 4 dates, 4 times, 2*2 fields (2 per request), 10 values per field (implicit axis)
     EXPECT_EQUAL(view->shape(), (std::vector<size_t>{4, 4, 4, 10}));
+}
+
+CASE("ChunkedDataView | View from 2 requests | NoChunking on extension axis") {
+    const std::string keys{
+        "type=an,"
+        "domain=g,"
+        "expver=0001,"
+        "stream=oper,"
+        "date=2020-01-01/to/2020-01-04,"
+        "levtype=sfc,"
+        "param=v/u,"
+        "time=0/6/12/18"};
+
+    const auto view =
+        cdv::ChunkedDataViewBuilder(
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    // MockListIterator skips first entry, so provide N+1 entries to return N messages
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                    });
+                }))
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .extendOnAxis(2)
+            .build();
+
+    // 4 dates, 4 times, 2+2=4 params (NoChunking), 10 values per field
+    EXPECT_EQUAL(view->shape(), (std::vector<size_t>{4, 4, 4, 10}));
+    EXPECT_EQUAL(view->chunks(), (std::vector<size_t>{4, 4, 1, 1}));
+    EXPECT_EQUAL(view->chunkShape(), (std::vector<size_t>{1, 1, 4, 10}));
+
+    // at() should succeed — each part contributes 2 params × 10 values = 20 floats
+    std::vector<float> buf(view->countChunkValues());
+    EXPECT_NO_THROW(view->at({0, 0, 0, 0}, buf.data(), buf.size()));
 }
 
 CASE("ChunkedDataView | View from 2 requests | Can compute shape, combined axis") {
@@ -295,12 +332,14 @@ CASE("ChunkedDataView | at | Wrong index dimension throws") {
 
     const auto view =
         cdv::ChunkedDataViewBuilder(
-            std::make_unique<MockFdb>([](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
-                                      [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
-                                          return std::make_unique<MockListIterator>(
-                                              std::vector<std::tuple<fdb5::Key, std::vector<double>>>{std::make_tuple(
-                                                  fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
-                                      }))
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+                }))
             .addPart(keys,
                      {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
                       cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
@@ -326,12 +365,14 @@ CASE("ChunkedDataView | at | Out-of-bounds chunk index throws") {
 
     const auto view =
         cdv::ChunkedDataViewBuilder(
-            std::make_unique<MockFdb>([](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
-                                      [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
-                                          return std::make_unique<MockListIterator>(
-                                              std::vector<std::tuple<fdb5::Key, std::vector<double>>>{std::make_tuple(
-                                                  fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
-                                      }))
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+                }))
             .addPart(keys,
                      {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
                       cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
@@ -356,6 +397,116 @@ CASE("ChunkedDataView | at | Out-of-bounds chunk index throws") {
 
     // Value chunk index out of bounds (1 >= 1)
     EXPECT_THROWS(view->at({0, 0, 0, 1}, buf.data(), buf.size()));
+}
+
+CASE("ChunkedDataView | at | Partial read throws") {
+    const std::string keys{
+        "type=an,domain=g,expver=0001,stream=oper,"
+        "date=2020-01-01/to/2020-01-04,levtype=sfc,"
+        "param=v/u,time=0/6/12/18"};
+
+    const auto view =
+        cdv::ChunkedDataViewBuilder(
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    // MockListIterator skips first entry: 2 entries → returns 1 message.
+                    // View expects 2 (2 params, NoChunking) → partial read.
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+                }))
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .build();
+
+    std::vector<float> buf(view->countChunkValues());
+    EXPECT_THROWS(view->at({0, 0, 0, 0}, buf.data(), buf.size()));
+}
+
+CASE("ChunkedDataView | at | Partial read in multi-part extension throws") {
+    const std::string keys{
+        "type=an,domain=g,expver=0001,stream=oper,"
+        "date=2020-01-01/to/2020-01-04,levtype=sfc,"
+        "param=v/u,time=0/6/12/18"};
+
+    const auto view =
+        cdv::ChunkedDataViewBuilder(
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    // Returns 1 message, but each part expects 2 (2 params, NoChunking)
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+                }))
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .extendOnAxis(2)
+            .build();
+
+    std::vector<float> buf(view->countChunkValues());
+    EXPECT_THROWS(view->at({0, 0, 0, 0}, buf.data(), buf.size()));
+}
+
+CASE("ChunkedDataView | View from 3 requests | Can compute shape and access") {
+    const std::string keys{
+        "type=an,"
+        "domain=g,"
+        "expver=0001,"
+        "stream=oper,"
+        "date=2020-01-01/to/2020-01-04,"
+        "levtype=sfc,"
+        "param=v/u,"
+        "time=0/6/12/18"};
+
+    const auto view =
+        cdv::ChunkedDataViewBuilder(
+            std::make_unique<MockFdb>(
+                [](auto& _) { return makeHandle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}); },
+                [](auto& _) -> std::unique_ptr<chunked_data_view::ListIteratorInterface> {
+                    return std::make_unique<MockListIterator>(std::vector<std::tuple<fdb5::Key, std::vector<double>>>{
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                        std::make_tuple(fdb5::Key(), std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+                    });
+                }))
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .addPart(keys,
+                     {cdv::AxisDefinition{{"date"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"time"}, cdv::AxisDefinition::IndividualChunking{}},
+                      cdv::AxisDefinition{{"param"}, cdv::AxisDefinition::NoChunking{}}},
+                     std::make_unique<FakeExtractor>())
+            .extendOnAxis(2)
+            .build();
+
+    // 4 dates, 4 times, 2+2+2=6 params (NoChunking), 10 values per field
+    EXPECT_EQUAL(view->shape(), (std::vector<size_t>{4, 4, 6, 10}));
+    EXPECT_EQUAL(view->chunks(), (std::vector<size_t>{4, 4, 1, 1}));
+    EXPECT_EQUAL(view->chunkShape(), (std::vector<size_t>{1, 1, 6, 10}));
+
+    std::vector<float> buf(view->countChunkValues());
+    EXPECT_NO_THROW(view->at({0, 0, 0, 0}, buf.data(), buf.size()));
 }
 
 int main(int argc, char** argv) {

--- a/tests/z3fdb/test_store_v3_errors.py
+++ b/tests/z3fdb/test_store_v3_errors.py
@@ -73,6 +73,42 @@ def test_missing_comma_between_keys(
         builder.build()
 
 
+@pytest.mark.parametrize("invalid_axis", [3, 4])
+def test_extend_on_invalid_axis_raises(
+    read_only_fdb_pattern_setup,
+    invalid_axis,
+) -> None:
+    builder = SimpleStoreBuilder(read_only_fdb_pattern_setup)
+
+    # Three axis definitions ⇒ valid extension axis indices are 0..2.
+    # Index 3 is the implicit field dimension (must not be used as extension
+    # axis); index 4 is strictly out of bounds.
+    builder.add_part(
+        "type=an,"
+        "class=ea,"
+        "domain=g,"
+        "expver=0001,"
+        "stream=oper,"
+        "time=0/6/12/18,"
+        "date=2020-01-01/to/2020-01-02,"
+        "levtype=sfc,"
+        "step=0,"
+        "param=165/166/167",
+        [
+            AxisDefinition(["date"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["time"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["param"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(invalid_axis)
+
+    # pybind11's default translation of eckit::UserError surfaces as
+    # RuntimeError, carrying the C++ exception's what() string.
+    with pytest.raises(RuntimeError, match="not referring to a valid axis"):
+        builder.build()
+
+
 def test_wrong_key(
     read_only_fdb_pattern_setup,
 ) -> None:

--- a/tests/z3fdb/test_store_v3_parts.py
+++ b/tests/z3fdb/test_store_v3_parts.py
@@ -57,9 +57,258 @@ def test_axis_check_merge(read_only_fdb_setup_for_sfc_pl_example) -> None:
 
     assert data
 
-    assert np.all(data[0, 0] == 0)
-    assert np.all(data[0, 1] == 1)
-    assert np.all(data[0, 2] == 31)
-    assert np.all(data[0, 3] == 33)
-    assert np.all(data[0, 4] == 32)
-    assert np.all(data[0, 5] == 34)
+    assert np.all(data[0, 0] == 0)   # date=20200101 time=0, 10u (sfc 165)
+    assert np.all(data[0, 1] == 1)   # date=20200101 time=0, 10v (sfc 166)
+    assert np.all(data[0, 2] == 31)  # date=20200101 time=0, u (pl 131) level=50
+    assert np.all(data[0, 3] == 33)  # date=20200101 time=0, u (pl 131) level=100
+    assert np.all(data[0, 4] == 32)  # date=20200101 time=0, v (pl 132) level=50
+    assert np.all(data[0, 5] == 34)  # date=20200101 time=0, v (pl 132) level=100
+
+
+def test_axis_check_merge_no_chunking(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """This test checks whether an access to an axis which has no pendant in the data is failing.
+    The request below has param 167 which is not given in the data of the setup fdb. Therefore this
+    needs to fail. Accessing the first two params is fine.
+    """
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        "type=an,"
+        "class=ea,"
+        "domain=g,"
+        "expver=0001,"
+        "stream=oper,"
+        "date=2020-01-01/2020-01-02,"
+        "levtype=sfc,"
+        "step=0,"
+        "param=165/166,"
+        "time=0/to/21/by/3",
+        [AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE), AxisDefinition(["param"], Chunking.NONE)],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        "type=an,"
+        "class=ea,"
+        "domain=g,"
+        "expver=0001,"
+        "stream=oper,"
+        "date=2020-01-01/2020-01-02,"
+        "levtype=pl,"
+        "step=0,"
+        "param=131/132,"
+        "levelist=50/100,"
+        "time=0/to/21/by/3",
+        [
+            AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["param", "levelist"], Chunking.NONE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(1)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    assert np.all(data[0, 0] == 0)   # date=20200101 time=0, 10u (sfc 165)
+    assert np.all(data[0, 1] == 1)   # date=20200101 time=0, 10v (sfc 166)
+    assert np.all(data[0, 2] == 31)  # date=20200101 time=0, u (pl 131) level=50
+    assert np.all(data[0, 3] == 33)  # date=20200101 time=0, u (pl 131) level=100
+    assert np.all(data[0, 4] == 32)  # date=20200101 time=0, v (pl 132) level=50
+    assert np.all(data[0, 5] == 34)  # date=20200101 time=0, v (pl 132) level=100
+
+
+SFC_REQUEST = (
+    "type=an,"
+    "class=ea,"
+    "domain=g,"
+    "expver=0001,"
+    "stream=oper,"
+    "date=2020-01-01/2020-01-02,"
+    "levtype=sfc,"
+    "step=0,"
+    "param=165/166,"
+    "time=0/to/21/by/3"
+)
+
+PL_REQUEST = (
+    "type=an,"
+    "class=ea,"
+    "domain=g,"
+    "expver=0001,"
+    "stream=oper,"
+    "date=2020-01-01/2020-01-02,"
+    "levtype=pl,"
+    "step=0,"
+    "param=131/132,"
+    "levelist=50/100,"
+    "time=0/to/21/by/3"
+)
+
+
+def test_extend_on_axis_0(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """Extension on axis 0 with SINGLE_VALUE chunking. Param axis before date+time."""
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        SFC_REQUEST,
+        [AxisDefinition(["param"], Chunking.SINGLE_VALUE), AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE)],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        PL_REQUEST,
+        [
+            AxisDefinition(["param", "levelist"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(0)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    # data[param_idx, date_time_idx]
+    assert np.all(data[0, 0] == 0)   # 10u (sfc 165), date=20200101 time=0
+    assert np.all(data[1, 0] == 1)   # 10v (sfc 166), date=20200101 time=0
+    assert np.all(data[2, 0] == 31)  # u (pl 131) level=50, date=20200101 time=0
+    assert np.all(data[3, 0] == 33)  # u (pl 131) level=100, date=20200101 time=0
+    assert np.all(data[4, 0] == 32)  # v (pl 132) level=50, date=20200101 time=0
+    assert np.all(data[5, 0] == 34)  # v (pl 132) level=100, date=20200101 time=0
+
+
+def test_extend_on_axis_0_no_chunking(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """Extension on axis 0 with NONE chunking on extension axis."""
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        SFC_REQUEST,
+        [AxisDefinition(["param"], Chunking.NONE), AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE)],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        PL_REQUEST,
+        [
+            AxisDefinition(["param", "levelist"], Chunking.NONE),
+            AxisDefinition(["date", "time"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(0)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    # data[param_idx, date_time_idx]
+    assert np.all(data[0, 0] == 0)   # 10u (sfc 165), date=20200101 time=0
+    assert np.all(data[1, 0] == 1)   # 10v (sfc 166), date=20200101 time=0
+    assert np.all(data[2, 0] == 31)  # u (pl 131) level=50, date=20200101 time=0
+    assert np.all(data[3, 0] == 33)  # u (pl 131) level=100, date=20200101 time=0
+    assert np.all(data[4, 0] == 32)  # v (pl 132) level=50, date=20200101 time=0
+    assert np.all(data[5, 0] == 34)  # v (pl 132) level=100, date=20200101 time=0
+
+
+def test_non_extension_axis_no_chunking(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """NONE chunking on non-extension axis (date+time), SINGLE_VALUE on extension axis (param)."""
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        SFC_REQUEST,
+        [AxisDefinition(["date", "time"], Chunking.NONE), AxisDefinition(["param"], Chunking.SINGLE_VALUE)],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        PL_REQUEST,
+        [
+            AxisDefinition(["date", "time"], Chunking.NONE),
+            AxisDefinition(["param", "levelist"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(1)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    # data[date_time_idx, param_idx]
+    assert np.all(data[0, 0] == 0)   # date=20200101 time=0, 10u (sfc 165)
+    assert np.all(data[0, 1] == 1)   # date=20200101 time=0, 10v (sfc 166)
+    assert np.all(data[1, 0] == 2)   # date=20200101 time=300, 10u (sfc 165)
+    assert np.all(data[0, 2] == 31)  # date=20200101 time=0, u (pl 131) level=50
+    assert np.all(data[0, 3] == 33)  # date=20200101 time=0, u (pl 131) level=100
+    assert np.all(data[0, 4] == 32)  # date=20200101 time=0, v (pl 132) level=50
+    assert np.all(data[0, 5] == 34)  # date=20200101 time=0, v (pl 132) level=100
+
+
+def test_single_key_axes(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """Separate date, time, param axes (no compound axes). Extension on axis 2."""
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        SFC_REQUEST,
+        [
+            AxisDefinition(["date"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["time"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["param"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        PL_REQUEST,
+        [
+            AxisDefinition(["date"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["time"], Chunking.SINGLE_VALUE),
+            AxisDefinition(["param", "levelist"], Chunking.SINGLE_VALUE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(2)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    # data[date_idx, time_idx, param_idx]
+    assert np.all(data[0, 0, 0] == 0)   # date=20200101, time=0, 10u (sfc 165)
+    assert np.all(data[0, 0, 1] == 1)   # date=20200101, time=0, 10v (sfc 166)
+    assert np.all(data[0, 0, 2] == 31)  # date=20200101, time=0, u (pl 131) level=50
+    assert np.all(data[0, 0, 3] == 33)  # date=20200101, time=0, u (pl 131) level=100
+    assert np.all(data[0, 0, 4] == 32)  # date=20200101, time=0, v (pl 132) level=50
+    assert np.all(data[0, 0, 5] == 34)  # date=20200101, time=0, v (pl 132) level=100
+    assert np.all(data[0, 1, 0] == 2)   # date=20200101, time=300, 10u (sfc 165)
+    assert np.all(data[1, 0, 0] == 16)  # date=20200102, time=0, 10u (sfc 165)
+
+
+def test_all_no_chunking(read_only_fdb_setup_for_sfc_pl_example) -> None:
+    """Both axes NONE. Extension on axis 1. Single giant chunk."""
+    builder = SimpleStoreBuilder(read_only_fdb_setup_for_sfc_pl_example)
+    builder.add_part(
+        SFC_REQUEST,
+        [AxisDefinition(["date", "time"], Chunking.NONE), AxisDefinition(["param"], Chunking.NONE)],
+        ExtractorType.GRIB,
+    )
+    builder.add_part(
+        PL_REQUEST,
+        [
+            AxisDefinition(["date", "time"], Chunking.NONE),
+            AxisDefinition(["param", "levelist"], Chunking.NONE),
+        ],
+        ExtractorType.GRIB,
+    )
+    builder.extend_on_axis(1)
+    store = builder.build()
+
+    data = zarr.open_array(store, mode="r", zarr_format=3, use_consolidated=False)
+
+    assert data
+
+    # data[date_time_idx, param_idx]
+    assert np.all(data[0, 0] == 0)   # date=20200101 time=0, 10u (sfc 165)
+    assert np.all(data[0, 1] == 1)   # date=20200101 time=0, 10v (sfc 166)
+    assert np.all(data[0, 2] == 31)  # date=20200101 time=0, u (pl 131) level=50
+    assert np.all(data[0, 3] == 33)  # date=20200101 time=0, u (pl 131) level=100
+    assert np.all(data[0, 4] == 32)  # date=20200101 time=0, v (pl 132) level=50
+    assert np.all(data[0, 5] == 34)  # date=20200101 time=0, v (pl 132) level=100


### PR DESCRIPTION
### Description

Now correctly retrieves data if non-chunked extension axis is defined.

Fixes: FDB 620

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-270
<!-- PREVIEW-PUBLISH-FDB_END -->