### PR TITLE
FDB-504: Cleanup environment variables

### DIFF
--- a/docs/fdb/content/environment-variables.rst
+++ b/docs/fdb/content/environment-variables.rst
@@ -26,6 +26,15 @@ This variable takes precedence over both ``FDB_CONFIG_FILE`` and the default con
 Deprecated. Equivalent to ``FDB_CONFIG``. If both are specified, ``FDB_CONFIG`` takes precedence over ``FDB5_CONFIG``.
 
 
+``FDB_SUB_TOCS``
+------------------
+
+If set to `1`, the FDB process will write to its own sub toc files instead of the main toc file.
+This mode is useful for avoiding contention on the main toc file when multiple FDB processes are writing concurrently.
+
+This variable overrides the `useSubToc` flag provided by the user config.
+
+
 ``FDB_CONFIG_FILE``
 --------------------
 

--- a/src/fdb5/LibFdb5.cc
+++ b/src/fdb5/LibFdb5.cc
@@ -101,27 +101,19 @@ static unsigned getUserEnvRemoteProtocol() {
     return 0;  // no version override
 }
 
-static bool getUserEnvSkipSanityCheck() {
-    return ::getenv("FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK");
-}
-
 RemoteProtocolVersion::RemoteProtocolVersion() {
     static unsigned user = getUserEnvRemoteProtocol();
-    static bool skipcheck = getUserEnvSkipSanityCheck();
 
     if (not user) {
         used_ = defaulted();
         return;
     }
 
-    if (not skipcheck) {
-        bool valid = check(user, false);
-        if (not valid) {
-            std::ostringstream msg;
-            msg << "Unsupported FDB5 remote protocol version " << user << " - supported: " << supportedStr()
-                << std::endl;
-            throw eckit::BadValue(msg.str(), Here());
-        }
+    bool valid = check(user, false);
+    if (not valid) {
+        std::ostringstream msg;
+        msg << "Unsupported FDB5 remote protocol version " << user << " - supported: " << supportedStr() << std::endl;
+        throw eckit::BadValue(msg.str(), Here());
     }
     used_ = user;
 }

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -150,7 +150,10 @@ TocHandler::TocHandler(const eckit::PathName& directory, const Config& config) :
     dirty_(false) {
     // An override to enable using sub tocs without configurations being passed in, for ease
     // of debugging
-    const char* subTocOverride = ::getenv("FDB5_SUB_TOCS");
+    const char* subTocOverride = ::getenv("FDB_SUB_TOCS");
+    if (!subTocOverride) {
+        subTocOverride = ::getenv("FDB5_SUB_TOCS");
+    }
     if (subTocOverride) {
         useSubToc_ = true;
     }


### PR DESCRIPTION
## Description

Redo of https://github.com/ecmwf/fdb/pull/230 as rebasing is tricky.

- Document FDB_SUB_TOCS
- Prefer FDB_SUB_TOCS over FDB5_SUB_TOCS
- Remove FDB5_SKIP_REMOTE_PROTOCOL_SANITY_CHECK

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-283
<!-- PREVIEW-PUBLISH-FDB_END -->