### PR TITLE
[python] add post compile to correct rpaths

### DIFF
--- a/python/fdb5lib/post-compile.sh
+++ b/python/fdb5lib/post-compile.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE=/tmp/fdb/target/fdb/bin
+
+for binary_path in "$BASE"/* ; do
+    [ -f "$binary_path" ] || continue
+    
+    binary_name=$(basename "$binary_path")
+
+    if [ "$(uname)" = "Darwin" ] ; then
+        # Check if file is a Mach-O binary
+        if file "$binary_path" | grep -q "Mach-O" ; then
+            echo "Processing macOS binary: $binary_name"
+            
+            # Extract existing LC_RPATH entries
+            current_rpaths=$(otool -l "$binary_path" | awk '/cmd LC_RPATH/{g=1;next} g&&/path/{print $2;g=0}')
+            
+            new_rpaths=()
+            for rpath in $current_rpaths; do
+                # Keep existing loader_path entries
+                if [[ "$rpath" == *'@loader_path'* ]]; then
+                    new_rpaths+=("$rpath")
+                # Convert prereqs paths to relative loader_path entries
+                elif [[ "$rpath" == *'prereqs'* ]]; then
+                    # Extract the library folder name (e.g., metkitlib)
+                    lib_dir=$(echo "$rpath" | sed -E 's|.*/prereqs/([^/]+)/.*|\1|')
+                    new_rpaths+=("@loader_path/../../$lib_dir/lib64")
+                fi
+            done
+            
+            # Delete all old RPATHs and inject the new filtered/relative ones
+            for rpath in $current_rpaths; do
+                # Ignore errors if a specific path removal fails
+                install_name_tool -delete_rpath "$rpath" "$binary_path" 2>/dev/null || true
+            done
+            
+            for rpath in "${new_rpaths[@]}"; do
+                install_name_tool -add_rpath "$rpath" "$binary_path"
+            done
+        fi
+
+    else
+        # Check if file is an ELF binary
+        if file "$binary_path" | grep -q "ELF" ; then
+            echo "Processing Linux binary: $binary_name"
+            
+            # Get current RPATH, suppress errors if none exists
+            current_rpath=$(patchelf --print-rpath "$binary_path" 2>/dev/null || echo "")
+            
+            if [ -n "$current_rpath" ]; then
+                # Split by colon into an array
+                IFS=':' read -r -a rpath_array <<< "$current_rpath"
+                new_rpaths=()
+                
+                for element in "${rpath_array[@]}"; do
+                    # Keep existing ORIGIN entries
+                    if [[ "$element" == *'$ORIGIN'* ]]; then
+                        new_rpaths+=("$element")
+                    # Convert prereqs paths to relative ORIGIN entries
+                    elif [[ "$element" == *'prereqs'* ]]; then
+                        # Extract the library folder name (e.g., metkitlib)
+                        lib_dir=$(echo "$element" | sed -E 's|.*/prereqs/([^/]+)/.*|\1|')
+                        new_rpaths+=("\$ORIGIN/../../$lib_dir/lib64")
+                    fi
+                done
+                
+                # Join the new array back together with colons
+                joined_rpath=$(IFS=:; echo "${new_rpaths[*]}")
+                
+                # Update the binary and shrink it to only these elements
+                patchelf --set-rpath "$joined_rpath" "$binary_path"
+            fi
+        fi
+    fi
+done

--- a/python/fdb5lib/post-compile.sh
+++ b/python/fdb5lib/post-compile.sh
@@ -25,7 +25,7 @@ for binary_path in "$BASE"/* ; do
                 elif [[ "$rpath" == *'prereqs'* ]]; then
                     # Extract the library folder name (e.g., metkitlib)
                     lib_dir=$(echo "$rpath" | sed -E 's|.*/prereqs/([^/]+)/.*|\1|')
-                    new_rpaths+=("@loader_path/../../$lib_dir/lib64")
+                    new_rpaths+=("@loader_path/../../$lib_dir/lib")
                 fi
             done
             


### PR DESCRIPTION
This makes the binaries distributed in the fdb5lib wheel contain the right relative rpaths. Not as strong as findlibs, but good enough for out of the box use

Test wheel publish: 
https://github.com/ecmwf/python-develop-bundle/actions/runs/28182996378/job/83477449822

I tested installing the wheel stack, importing pyfdb, and running the executables in the bin folder -- completely shallowly, just that "it does not crash on invocation". I tested **Linux only**

<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-291
<!-- PREVIEW-PUBLISH-FDB_END -->