### PR TITLE
Fix issue building fam tools on mac

### DIFF
--- a/src/fdb5/tools/fdb-fam.cc
+++ b/src/fdb5/tools/fdb-fam.cc
@@ -46,7 +46,7 @@ public:  // methods
         options_.push_back(new eckit::option::SimpleOption<bool>("lookup", "Lookup item"));
 
         options_.push_back(new eckit::option::SimpleOption<bool>("create", "Create item if it doesn't exist"));
-        options_.push_back(new eckit::option::SimpleOption<std::uint64_t>("size", "Size in bytes (needed by create)"));
+        options_.push_back(new eckit::option::SimpleOption<std::size_t>("size", "Size in bytes (needed by create)"));
         options_.push_back(new eckit::option::SimpleOption<std::string>("perm", "Permissions (needed by create)"));
 
         options_.push_back(new eckit::option::SimpleOption<bool>("delete", "Delete item if it exists"));


### PR DESCRIPTION
### Description

I find on mac/clang `SimpleOption<std::uint64_t>` fails at compile time when fdb-fam is built:
```
no matching member function for call to 'get'
call to member function 'set' is ambiguous
```
because `std::uint64_t` is an alias for unsigned long long on this platform, and eckit has no exact get(..., unsigned long long&) / set(..., unsigned long long) overloads. It does have std::size_t, so I propose we just use that.*

*Unless there is a specific reason why uint64 must be used, in which case eckit::Configuration probably needs a new setter/getter for unsigned long long. But this is simpler.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-314
<!-- PREVIEW-PUBLISH-FDB_END -->