### PR TITLE
remote teardown

### DIFF
--- a/src/fdb5/api/RemoteFDB.cc
+++ b/src/fdb5/api/RemoteFDB.cc
@@ -28,12 +28,11 @@
 #include "eckit/utils/Literals.h"
 
 #include <cstdint>
-#include <cstdlib>
-#include <ctime>
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <ostream>
+#include <random>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -164,7 +163,8 @@ const net::Endpoint& RemoteFDB::storeEndpoint() const {
     if (storesLocalFields_.empty()) {
         throw SeriousBug("Unable to find a store to serve local data");
     }
-    return storesLocalFields_.at(std::rand() % storesLocalFields_.size());
+    thread_local std::mt19937 rndGen{std::random_device{}()};
+    return storesLocalFields_.at(std::uniform_int_distribution<size_t>(0, storesLocalFields_.size() - 1)(rndGen));
 }
 const net::Endpoint& RemoteFDB::storeEndpoint(const net::Endpoint& fieldLocationEndpoint) const {
     // looking for an alias for the given endpoint

--- a/src/fdb5/api/RemoteFDB.cc
+++ b/src/fdb5/api/RemoteFDB.cc
@@ -246,7 +246,7 @@ RemoteFDB::RemoteFDB(const Configuration& config, const std::string& name) : Loc
 
 RemoteFDB::~RemoteFDB() {
     // 1- stop listening thread dispatching to this client
-    connection_->remove(id());
+    deregister();
     // 2- wait for any handle() before destroying
     std::lock_guard lock(messageQueueMutex_);
 }

--- a/src/fdb5/api/RemoteFDB.cc
+++ b/src/fdb5/api/RemoteFDB.cc
@@ -163,8 +163,7 @@ const net::Endpoint& RemoteFDB::storeEndpoint() const {
     if (storesLocalFields_.empty()) {
         throw SeriousBug("Unable to find a store to serve local data");
     }
-    thread_local std::mt19937 rndGen{std::random_device{}()};
-    return storesLocalFields_.at(std::uniform_int_distribution<size_t>(0, storesLocalFields_.size() - 1)(rndGen));
+    return storesLocalFields_.at(remote::random(storesLocalFields_.size() - 1));
 }
 const net::Endpoint& RemoteFDB::storeEndpoint(const net::Endpoint& fieldLocationEndpoint) const {
     // looking for an alias for the given endpoint

--- a/src/fdb5/remote/Connection.cc
+++ b/src/fdb5/remote/Connection.cc
@@ -1,12 +1,14 @@
+#include "fdb5/remote/Connection.h"
+
+#include "fdb5/LibFdb5.h"
+#include "fdb5/remote/Messages.h"
+
 #include "eckit/io/Buffer.h"
 #include "eckit/log/Log.h"
 
 #include <cstdint>
 #include <mutex>
 #include <string_view>
-#include "fdb5/LibFdb5.h"
-#include "fdb5/remote/Connection.h"
-#include "fdb5/remote/Messages.h"
 
 namespace fdb5::remote {
 
@@ -15,7 +17,9 @@ namespace fdb5::remote {
 Connection::Connection() : single_(false) {}
 
 void Connection::teardown() {
-    closingSocket_ = true;
+    if (closingSocket_.exchange(true)) {
+        return;
+    }
 
     if (!valid()) {
         return;

--- a/src/fdb5/remote/FdbServer.cc
+++ b/src/fdb5/remote/FdbServer.cc
@@ -44,10 +44,6 @@ void FDBForker::run() {
 
     eckit::Monitor::instance().reset();  // needed to the monitor to work on forked (but not execed process)
 
-    // Ensure random state is reset after fork
-    ::srand(::getpid() + ::time(nullptr));
-    ::srandom(::getpid() + ::time(nullptr));
-
     eckit::Log::info() << "FDB forked pid " << ::getpid() << "  --  connection: " << socket_.localHost() << ":"
                        << socket_.localPort() << "-->" << socket_.remoteHost() << ":" << socket_.remotePort()
                        << std::endl;

--- a/src/fdb5/remote/client/Client.cc
+++ b/src/fdb5/remote/client/Client.cc
@@ -80,6 +80,20 @@ Client::~Client() {
     deregister();
 }
 
+eckit::Buffer Client::waitControlResponse(std::future<eckit::Buffer>& response, const Message msg,
+                                          const uint32_t requestID) const {
+    try {
+        response.wait();
+        return response.get();
+    }
+    catch (const std::exception& e) {
+        std::ostringstream ss;
+        ss << "Error while waiting for response to control message " << msg << " with requestID " << requestID << ": "
+           << e.what();
+        throw RemoteFDBException(ss.str(), connection_->controlEndpoint());
+    }
+}
+
 void Client::controlWriteCheckResponse(const Message msg, const uint32_t requestID, const bool dataListener,
                                        const void* const payload, const uint32_t payloadLength) const {
 
@@ -92,17 +106,8 @@ void Client::controlWriteCheckResponse(const Message msg, const uint32_t request
         payloads.emplace_back(payloadLength, payload);
     }
 
-    auto f = connection_->controlWrite(*this, msg, requestID, dataListener, payloads);
-    try {
-        f.wait();
-        ASSERT(f.get().size() == 0);
-    }
-    catch (const std::exception& e) {
-        std::ostringstream ss;
-        ss << "Error while waiting for response to control message " << msg << " with requestID " << requestID << ": "
-           << e.what();
-        throw RemoteFDBException(ss.str(), connection_->controlEndpoint());
-    }
+    auto response = connection_->controlWrite(*this, msg, requestID, dataListener, payloads);
+    ASSERT(waitControlResponse(response, msg, requestID).size() == 0);
 }
 
 eckit::Buffer Client::controlWriteReadResponse(const Message msg, const uint32_t requestID, const void* const payload,
@@ -117,17 +122,8 @@ eckit::Buffer Client::controlWriteReadResponse(const Message msg, const uint32_t
         payloads.emplace_back(payloadLength, payload);
     }
 
-    auto f = connection_->controlWrite(*this, msg, requestID, false, payloads);
-    try {
-        f.wait();
-        return eckit::Buffer{f.get()};
-    }
-    catch (const std::exception& e) {
-        std::ostringstream ss;
-        ss << "Error while waiting for response to control message " << msg << " with requestID " << requestID << ": "
-           << e.what();
-        throw RemoteFDBException(ss.str(), connection_->controlEndpoint());
-    }
+    auto response = connection_->controlWrite(*this, msg, requestID, false, payloads);
+    return waitControlResponse(response, msg, requestID);
 }
 
 void Client::dataWrite(Message msg, uint32_t requestID, PayloadList payloads) {

--- a/src/fdb5/remote/client/Client.cc
+++ b/src/fdb5/remote/client/Client.cc
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <future>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -69,8 +70,14 @@ void Client::refreshConnection() {
     connection_->add(*this);
 }
 
+void Client::deregister() {
+    if (!deregistered_.exchange(true)) {
+        connection_->remove(id_);
+    }
+}
+
 Client::~Client() {
-    connection_->remove(id_);
+    deregister();
 }
 
 void Client::controlWriteCheckResponse(const Message msg, const uint32_t requestID, const bool dataListener,
@@ -86,8 +93,16 @@ void Client::controlWriteCheckResponse(const Message msg, const uint32_t request
     }
 
     auto f = connection_->controlWrite(*this, msg, requestID, dataListener, payloads);
-    f.wait();
-    ASSERT(f.get().size() == 0);
+    try {
+        f.wait();
+        ASSERT(f.get().size() == 0);
+    }
+    catch (const std::exception& e) {
+        std::ostringstream ss;
+        ss << "Error while waiting for response to control message " << msg << " with requestID " << requestID << ": "
+           << e.what();
+        throw RemoteFDBException(ss.str(), connection_->controlEndpoint());
+    }
 }
 
 eckit::Buffer Client::controlWriteReadResponse(const Message msg, const uint32_t requestID, const void* const payload,
@@ -103,8 +118,16 @@ eckit::Buffer Client::controlWriteReadResponse(const Message msg, const uint32_t
     }
 
     auto f = connection_->controlWrite(*this, msg, requestID, false, payloads);
-    f.wait();
-    return eckit::Buffer{f.get()};
+    try {
+        f.wait();
+        return eckit::Buffer{f.get()};
+    }
+    catch (const std::exception& e) {
+        std::ostringstream ss;
+        ss << "Error while waiting for response to control message " << msg << " with requestID " << requestID << ": "
+           << e.what();
+        throw RemoteFDBException(ss.str(), connection_->controlEndpoint());
+    }
 }
 
 void Client::dataWrite(Message msg, uint32_t requestID, PayloadList payloads) {

--- a/src/fdb5/remote/client/Client.h
+++ b/src/fdb5/remote/client/Client.h
@@ -18,6 +18,7 @@
 #include "eckit/utils/Literals.h"
 
 #include <atomic>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <utility>  // std::pair
@@ -103,6 +104,9 @@ protected:
 private:
 
     void setClientID();
+
+    // rethrows any exception as a RemoteFDBException.
+    eckit::Buffer waitControlResponse(std::future<eckit::Buffer>& response, Message msg, uint32_t requestID) const;
 
 private:
 

--- a/src/fdb5/remote/client/Client.h
+++ b/src/fdb5/remote/client/Client.h
@@ -10,13 +10,15 @@
 
 #pragma once
 
-#include "eckit/net/Endpoint.h"
-#include "eckit/utils/Literals.h"
-
 #include "fdb5/remote/Connection.h"
 #include "fdb5/remote/Messages.h"
 #include "fdb5/remote/client/ClientConnection.h"
 
+#include "eckit/net/Endpoint.h"
+#include "eckit/utils/Literals.h"
+
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <utility>  // std::pair
 #include <vector>
@@ -91,6 +93,11 @@ public:  // methods
 
 protected:
 
+    // Deregister this client from its connection. Idempotent.
+    // Derived classes accessed by handle() should call this
+    // in their destructor, before that state is destroyed.
+    void deregister();
+
     std::shared_ptr<ClientConnection> connection_;
 
 private:
@@ -100,6 +107,7 @@ private:
 private:
 
     uint32_t id_;
+    std::atomic<bool> deregistered_{false};
     mutable std::mutex blockingRequestMutex_;
 };
 

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -403,7 +403,7 @@ void ClientConnection::listeningControlThreadLoop() {
                 // only a Received/Error may fulfill a promise
                 if (hdr.message == Message::Received || hdr.message == Message::Error) {
                     // Hold promisesMutex_ only for the promise lookup/erase (NOT across handle(); risk a deadlock.
-                    std::lock_guard<std::mutex> lock(promisesMutex_);
+                    std::lock_guard lock(promisesMutex_);
 
                     auto pp = promises_.find(hdr.requestID);
                     if (pp != promises_.end()) {

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -193,9 +193,14 @@ RemoteConfiguration ClientConnection::availableFunctionality(const Configuration
 
 std::future<Buffer> ClientConnection::controlWrite(const Client& client, const Message msg, const uint32_t requestID,
                                                    const bool /*dataListener*/, const PayloadList payloads) const {
+    if (!valid()) {
+        throw RemoteFDBException("Connection to " + std::string(controlEndpoint_) + " is no longer valid",
+                                 controlEndpoint_);
+    }
+
     std::future<Buffer> f;
     {
-        std::lock_guard<std::mutex> lock(promisesMutex_);
+        std::lock_guard lock(promisesMutex_);
         auto pp = promises_.emplace(requestID, std::promise<Buffer>{}).first;
         f = pp->second.get_future();
     }
@@ -220,7 +225,7 @@ void ClientConnection::dataWrite(Client& client, remote::Message msg, uint32_t r
     }
 
     {
-        std::lock_guard<std::mutex> lock(dataWriteMutex_);
+        std::lock_guard lock(dataWriteMutex_);
         if (!dataWriteThread_.joinable()) {
             // Reset the queue after previous done/errors
             ASSERT(!dataWriteQueue_);
@@ -336,18 +341,35 @@ SessionID ClientConnection::verifyServerStartupResponse() {
     return serverSession;
 }
 
+void ClientConnection::failPendingRequests(const std::exception_ptr& eptr) {
+    std::lock_guard lock(promisesMutex_);
+    for (auto& [requestID, promise] : promises_) {
+        promise.set_exception(eptr);
+    }
+    promises_.clear();
+}
+
 void ClientConnection::handleConnectionError(const std::exception_ptr& eptr) {
+    std::string reason;
     try {
         if (eptr) {
             std::rethrow_exception(eptr);
         }
     }
     catch (const std::exception& e) {
-        Log::error() << "error: " << e.what() << std::endl;
+        reason = e.what();
+        Log::error() << "error: " << reason << std::endl;
     }
     catch (...) {
+        reason = "unknown exception";
         Log::error() << "error: unknown exception on connection " << controlEndpoint_ << std::endl;
     }
+
+    // nothing else will ever fulfil a promise once the listening thread has stopped
+    std::ostringstream ss;
+    ss << "Connection to " << controlEndpoint_ << " lost: " << reason;
+    failPendingRequests(std::make_exception_ptr(RemoteFDBException(ss.str(), controlEndpoint_)));
+
     teardown();
 }
 

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -81,7 +81,13 @@ bool ClientConnection::remove(uint32_t clientID) {
 
         if (it != clients_.end()) {
             if (valid()) {
-                Connection::write(Message::Stop, true, clientID, 0);
+                try {
+                    Connection::write(Message::Stop, true, clientID, 0);
+                }
+                catch (...) {
+                    Log::error() << "ClientConnection::remove() - failed to send STOP message to server for clientID "
+                                 << clientID << std::endl;
+                }
             }
 
             clients_.erase(it);
@@ -399,23 +405,21 @@ void ClientConnection::listeningControlThreadLoop() {
                     }
                 }
                 if (!isPromise) {
-                    Client* client = nullptr;
-                    {
-                        std::lock_guard lock(clientsMutex_);
+                    // Hold clientsMutex_ across the virtual dispatch too (not just the lookup)
+                    std::lock_guard lock(clientsMutex_);
 
-                        auto it = clients_.find(hdr.clientID());
-                        if (it == clients_.end()) {
-                            std::ostringstream ss;
-                            ss << "ERROR: CONTROL connection=" << controlEndpoint_
-                               << " received [clientID=" << hdr.clientID() << ",requestID=" << hdr.requestID
-                               << ",message=" << hdr.message << ",payload=" << hdr.payloadSize << "]" << std::endl;
-                            ss << "ClientID (" << hdr.clientID() << ") not found. ABORTING";
-                            Log::status() << ss.str() << std::endl;
-                            Log::error() << "Retrieving... " << ss.str() << std::endl;
-                            throw SeriousBug(ss.str(), Here());
-                        }
-                        client = it->second;
+                    auto it = clients_.find(hdr.clientID());
+                    if (it == clients_.end()) {
+                        std::ostringstream ss;
+                        ss << "ERROR: CONTROL connection=" << controlEndpoint_
+                           << " received [clientID=" << hdr.clientID() << ",requestID=" << hdr.requestID
+                           << ",message=" << hdr.message << ",payload=" << hdr.payloadSize << "]" << std::endl;
+                        ss << "ClientID (" << hdr.clientID() << ") not found. ABORTING";
+                        Log::status() << ss.str() << std::endl;
+                        Log::error() << "Retrieving... " << ss.str() << std::endl;
+                        throw SeriousBug(ss.str(), Here());
                     }
+                    Client* client = it->second;
 
                     if (hdr.payloadSize == 0) {
                         handled = client->handle(hdr.message, hdr.requestID);
@@ -485,23 +489,21 @@ void ClientConnection::listeningDataThreadLoop() {
             }
             if (hdr.clientID()) {
                 bool handled = false;
-                Client* client = nullptr;
-                {
-                    std::lock_guard lock(clientsMutex_);
+                // Hold clientsMutex_ across the virtual dispatch too (not just the lookup)
+                std::lock_guard lock(clientsMutex_);
 
-                    auto it = clients_.find(hdr.clientID());
-                    if (it == clients_.end()) {
-                        std::ostringstream ss;
-                        ss << "ERROR: DATA connection=" << dataEndpoint_ << " received [clientID=" << hdr.clientID()
-                           << ",requestID=" << hdr.requestID << ",message=" << hdr.message
-                           << ",payload=" << hdr.payloadSize << "]" << std::endl;
-                        ss << "ClientID (" << hdr.clientID() << ") not found. ABORTING";
-                        Log::status() << ss.str() << std::endl;
-                        Log::error() << "Retrieving... " << ss.str() << std::endl;
-                        throw SeriousBug(ss.str(), Here());
-                    }
-                    client = it->second;
+                auto it = clients_.find(hdr.clientID());
+                if (it == clients_.end()) {
+                    std::ostringstream ss;
+                    ss << "ERROR: DATA connection=" << dataEndpoint_ << " received [clientID=" << hdr.clientID()
+                       << ",requestID=" << hdr.requestID << ",message=" << hdr.message << ",payload=" << hdr.payloadSize
+                       << "]" << std::endl;
+                    ss << "ClientID (" << hdr.clientID() << ") not found. ABORTING";
+                    Log::status() << ss.str() << std::endl;
+                    Log::error() << "Retrieving... " << ss.str() << std::endl;
+                    throw SeriousBug(ss.str(), Here());
                 }
+                Client* client = it->second;
 
                 ASSERT(client);
                 ASSERT(!hdr.control());

--- a/src/fdb5/remote/client/ClientConnection.cc
+++ b/src/fdb5/remote/client/ClientConnection.cc
@@ -399,9 +399,7 @@ void ClientConnection::listeningControlThreadLoop() {
                 ASSERT(hdr.control() || single_);
 
                 bool isPromise = false;
-                // messages "Blob/Complete/Store/etc" must be dispatched to the client
-                // only a Received/Error may fulfill a promise
-                if (hdr.message == Message::Received || hdr.message == Message::Error) {
+                {
                     // Hold promisesMutex_ only for the promise lookup/erase (NOT across handle(); risk a deadlock.
                     std::lock_guard lock(promisesMutex_);
 

--- a/src/fdb5/remote/client/ClientConnection.h
+++ b/src/fdb5/remote/client/ClientConnection.h
@@ -90,6 +90,9 @@ private:  // methods
     // Tears down *only this* connection
     void handleConnectionError(const std::exception_ptr& eptr);
 
+    // do not hang forever once the connection is known to be dead.
+    void failPendingRequests(const std::exception_ptr& eptr);
+
     void dataWriteThreadLoop();
     void closeConnection();
 

--- a/src/fdb5/remote/client/ClientConnectionRouter.cc
+++ b/src/fdb5/remote/client/ClientConnectionRouter.cc
@@ -43,6 +43,12 @@ ConnectionError::ConnectionError(const eckit::net::Endpoint& endpoint) {
 }  // namespace
 namespace fdb5::remote {
 
+size_t random(size_t const max) {
+    thread_local std::mt19937 rndGen{ std::random_device{}() };
+    thread_local std::uniform_int_distribution<size_t> dist;
+    return dist(rndGen, std::uniform_int_distribution<size_t>::param_type{ 0, max });
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 std::shared_ptr<ClientConnection> ClientConnectionRouter::connection(const eckit::Configuration& config,
@@ -72,8 +78,7 @@ std::shared_ptr<ClientConnection> ClientConnectionRouter::connection(
     reap();
     while (fullEndpoints.size() > 0) {
         // select a random endpoint
-        thread_local std::mt19937 rndGen{std::random_device{}()};
-        size_t idx = std::uniform_int_distribution<size_t>(0, fullEndpoints.size() - 1)(rndGen);
+        size_t idx = random(fullEndpoints.size() - 1);
         eckit::net::Endpoint endpoint = fullEndpoints.at(idx).first;
 
         // look for the selected endpoint (a dead connection must not be handed out; replace it)

--- a/src/fdb5/remote/client/ClientConnectionRouter.cc
+++ b/src/fdb5/remote/client/ClientConnectionRouter.cc
@@ -7,10 +7,10 @@
 #include "eckit/net/Endpoint.h"
 
 #include <cstddef>
-#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <ostream>
+#include <random>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -72,7 +72,8 @@ std::shared_ptr<ClientConnection> ClientConnectionRouter::connection(
     reap();
     while (fullEndpoints.size() > 0) {
         // select a random endpoint
-        size_t idx = std::rand() % fullEndpoints.size();
+        thread_local std::mt19937 rndGen{std::random_device{}()};
+        size_t idx = std::uniform_int_distribution<size_t>(0, fullEndpoints.size() - 1)(rndGen);
         eckit::net::Endpoint endpoint = fullEndpoints.at(idx).first;
 
         // look for the selected endpoint (a dead connection must not be handed out; replace it)

--- a/src/fdb5/remote/client/ClientConnectionRouter.cc
+++ b/src/fdb5/remote/client/ClientConnectionRouter.cc
@@ -145,7 +145,9 @@ void ClientConnectionRouter::deregister(ClientConnection& connection) {
 }
 
 ClientConnectionRouter& ClientConnectionRouter::instance() {
-    static ClientConnectionRouter router;
+    // Leaked deliberately: avoids racing this destructor against other threads tearing
+    // down connections during static/process deinitialisation.
+    static ClientConnectionRouter& router = *new ClientConnectionRouter();
     return router;
 }
 

--- a/src/fdb5/remote/client/ClientConnectionRouter.h
+++ b/src/fdb5/remote/client/ClientConnectionRouter.h
@@ -25,6 +25,7 @@ class Configuration;
 namespace fdb5::remote {
 
 //----------------------------------------------------------------------------------------------------------------------
+size_t random(size_t const max);
 
 class ClientConnectionRouter {
 public:

--- a/src/fdb5/remote/client/RemoteCatalogue.cc
+++ b/src/fdb5/remote/client/RemoteCatalogue.cc
@@ -66,7 +66,7 @@ RemoteCatalogue::RemoteCatalogue(const eckit::URI& /*uri*/, const Config& config
 
 RemoteCatalogue::~RemoteCatalogue() {
     // stop listening otherwise it may invoke a virtual call - e.g. closeConnection()
-    connection_->remove(id());
+    deregister();
 }
 
 void RemoteCatalogue::archive(const Key& idxKey, const Key& datumKey,

--- a/src/fdb5/remote/client/RemoteCatalogue.cc
+++ b/src/fdb5/remote/client/RemoteCatalogue.cc
@@ -10,16 +10,16 @@
 
 #include "fdb5/remote/client/RemoteCatalogue.h"
 
-#include "eckit/serialisation/ResizableMemoryStream.h"
 #include "fdb5/LibFdb5.h"
 #include "fdb5/database/Key.h"
+#include "fdb5/database/WipeState.h"
 #include "fdb5/remote/Messages.h"
+#include "fdb5/rules/Schema.h"
 
 #include "eckit/filesystem/URI.h"
 #include "eckit/log/Log.h"
 #include "eckit/serialisation/MemoryStream.h"
-#include "fdb5/database/WipeState.h"
-#include "fdb5/rules/Schema.h"
+#include "eckit/serialisation/ResizableMemoryStream.h"
 
 #include <cstddef>
 #include <memory>
@@ -64,7 +64,10 @@ RemoteCatalogue::RemoteCatalogue(const eckit::URI& /*uri*/, const Config& config
     NOTIMP;
 }
 
-RemoteCatalogue::~RemoteCatalogue() = default;
+RemoteCatalogue::~RemoteCatalogue() {
+    // stop listening otherwise it may invoke a virtual call - e.g. closeConnection()
+    connection_->remove(id());
+}
 
 void RemoteCatalogue::archive(const Key& idxKey, const Key& datumKey,
                               std::shared_ptr<const FieldLocation> fieldLocation) {

--- a/src/fdb5/remote/client/RemoteStore.cc
+++ b/src/fdb5/remote/client/RemoteStore.cc
@@ -424,7 +424,7 @@ bool RemoteStore::handle(Message message, uint32_t requestID, eckit::Buffer&& pa
             return locations_.location(requestID, std::move(remoteLocation));
         }
         case Message::Blob: {
-            std::lock_guard<std::mutex> lock(messageMutex_);
+            std::lock_guard lock(messageMutex_);
             auto iter = messageQueues_.find(requestID);
             ASSERT(iter != messageQueues_.end());
             iter->second->emplace(std::make_pair(message, std::move(payload)));
@@ -478,7 +478,7 @@ RemoteStore& RemoteStore::get(const eckit::URI& uri) {
     // we memoise one read store for each endpoint. Do not need to have one for each key
     static std::map<std::string, std::unique_ptr<RemoteStore>> readStores_;
 
-    std::lock_guard<std::mutex> lock(storeMutex_);
+    std::lock_guard lock(storeMutex_);
     const std::string& endpoint = uri.hostport();
     auto it = readStores_.find(endpoint);
     if (it != readStores_.end()) {

--- a/src/fdb5/remote/client/RemoteStore.cc
+++ b/src/fdb5/remote/client/RemoteStore.cc
@@ -419,30 +419,29 @@ bool RemoteStore::handle(Message message, uint32_t requestID, eckit::Buffer&& pa
             if (defaultEndpoint().empty()) {
                 return locations_.location(requestID, std::move(location));
             }
-            std::unique_ptr<RemoteFieldLocation> remoteLocation = std::unique_ptr<RemoteFieldLocation>(
-                new RemoteFieldLocation(eckit::net::Endpoint{defaultEndpoint()}, *location));
+            auto remoteLocation =
+                std::make_unique<RemoteFieldLocation>(eckit::net::Endpoint{defaultEndpoint()}, *location);
             return locations_.location(requestID, std::move(remoteLocation));
         }
         case Message::Blob: {
             std::lock_guard<std::mutex> lock(messageMutex_);
-            auto id = messageQueues_.find(requestID);
-            ASSERT(id != messageQueues_.end());
-            id->second->emplace(std::make_pair(message, std::move(payload)));
+            auto iter = messageQueues_.find(requestID);
+            ASSERT(iter != messageQueues_.end());
+            iter->second->emplace(std::make_pair(message, std::move(payload)));
             return true;
         }
         case Message::Error: {
-
             std::lock_guard lock(messageMutex_);
-            auto it = messageQueues_.find(requestID);
-            if (it != messageQueues_.end()) {
+            auto iter = messageQueues_.find(requestID);
+            if (iter != messageQueues_.end()) {
                 std::string msg;
                 msg.resize(payload.size(), ' ');
                 payload.copy(&msg[0], payload.size());
-                it->second->interrupt(std::make_exception_ptr(RemoteFDBException(msg, controlEndpoint())));
+                iter->second->interrupt(std::make_exception_ptr(RemoteFDBException(msg, controlEndpoint())));
 
                 // Remove entry (shared_ptr --> message queue will be destroyed when it
                 // goes out of scope in the worker thread).
-                messageQueues_.erase(it);
+                messageQueues_.erase(iter);
             }
             return true;
         }

--- a/src/fdb5/remote/client/RemoteStore.cc
+++ b/src/fdb5/remote/client/RemoteStore.cc
@@ -245,6 +245,11 @@ RemoteStore::RemoteStore(const eckit::URI& uri, const Config& config) :
 }
 
 RemoteStore::~RemoteStore() {
+    // stop listening otherwise it may invoke a virtual call - e.g. closeConnection()
+    connection_->remove(id());
+
+    std::lock_guard lock(retrieveMessageMutex_);
+
     // If we have launched a thread with an async and we manage to get here, this is
     // an error. n.b. if we don't do something, we will block in the destructor
     // of std::future.

--- a/src/fdb5/remote/client/RemoteStore.cc
+++ b/src/fdb5/remote/client/RemoteStore.cc
@@ -246,9 +246,9 @@ RemoteStore::RemoteStore(const eckit::URI& uri, const Config& config) :
 
 RemoteStore::~RemoteStore() {
     // stop listening otherwise it may invoke a virtual call - e.g. closeConnection()
-    connection_->remove(id());
+    deregister();
 
-    std::lock_guard lock(retrieveMessageMutex_);
+    std::lock_guard lock(messageMutex_);
 
     // If we have launched a thread with an async and we manage to get here, this is
     // an error. n.b. if we don't do something, we will block in the destructor
@@ -366,12 +366,8 @@ void RemoteStore::print(std::ostream& out) const {
 }
 
 void RemoteStore::closeConnection() {
+    std::lock_guard lock(messageMutex_);
     for (auto& kv : messageQueues_) {
-        if (!kv.second->closed()) {
-            kv.second->interrupt(std::make_exception_ptr(eckit::Exception("Unexpected closure of store", Here())));
-        }
-    }
-    for (auto& kv : retrieveMessageQueues_) {
         if (!kv.second->closed()) {
             kv.second->interrupt(std::make_exception_ptr(eckit::Exception("Unexpected closure of store", Here())));
         }
@@ -386,26 +382,17 @@ bool RemoteStore::handle(Message message, uint32_t requestID) {
 
     switch (message) {
         case Message::Complete: {
-            // eckit::Log::info() << "RemoteStore::handle COMPLETE" << std::endl;
-            auto it = messageQueues_.find(requestID);
-            if (it != messageQueues_.end()) {
-                // eckit::Log::info() << "RemoteStore::handle COMPLETE close and erase queue" << std::endl;
-                it->second->close();
-
-                // Remove entry (shared_ptr --> message queue will be destroyed when it
-                // goes out of scope in the worker thread).
-                messageQueues_.erase(it);
-                // eckit::Log::info() << "RemoteStore::handle COMPLETE closed and erased queue" << std::endl;
+            std::lock_guard lock(messageMutex_);
+            auto id = messageQueues_.find(requestID);
+            if (id == messageQueues_.end()) {
+                return false;
             }
-            else {
-                std::lock_guard<std::mutex> lock(retrieveMessageMutex_);
-                auto id = retrieveMessageQueues_.find(requestID);
-                ASSERT(id != retrieveMessageQueues_.end());
 
-                id->second->emplace(std::make_pair(message, Buffer(0)));
+            id->second->emplace(std::make_pair(message, Buffer(0)));
 
-                retrieveMessageQueues_.erase(id);
-            }
+            // Remove entry (shared_ptr --> message queue will be destroyed when it
+            // goes out of scope in the worker thread).
+            messageQueues_.erase(id);
             return true;
         }
         case Message::Error: {
@@ -432,27 +419,20 @@ bool RemoteStore::handle(Message message, uint32_t requestID, eckit::Buffer&& pa
             if (defaultEndpoint().empty()) {
                 return locations_.location(requestID, std::move(location));
             }
-            else {
-                std::unique_ptr<RemoteFieldLocation> remoteLocation = std::unique_ptr<RemoteFieldLocation>(
-                    new RemoteFieldLocation(eckit::net::Endpoint{defaultEndpoint()}, *location));
-                return locations_.location(requestID, std::move(remoteLocation));
-            }
+            std::unique_ptr<RemoteFieldLocation> remoteLocation = std::unique_ptr<RemoteFieldLocation>(
+                new RemoteFieldLocation(eckit::net::Endpoint{defaultEndpoint()}, *location));
+            return locations_.location(requestID, std::move(remoteLocation));
         }
         case Message::Blob: {
-            auto it = messageQueues_.find(requestID);
-            if (it != messageQueues_.end()) {
-                it->second->emplace(message, std::move(payload));
-            }
-            else {
-                std::lock_guard<std::mutex> lock(retrieveMessageMutex_);
-                auto id = retrieveMessageQueues_.find(requestID);
-                ASSERT(id != retrieveMessageQueues_.end());
-                id->second->emplace(std::make_pair(message, std::move(payload)));
-            }
+            std::lock_guard<std::mutex> lock(messageMutex_);
+            auto id = messageQueues_.find(requestID);
+            ASSERT(id != messageQueues_.end());
+            id->second->emplace(std::make_pair(message, std::move(payload)));
             return true;
         }
         case Message::Error: {
 
+            std::lock_guard lock(messageMutex_);
             auto it = messageQueues_.find(requestID);
             if (it != messageQueues_.end()) {
                 std::string msg;
@@ -482,9 +462,9 @@ eckit::DataHandle* RemoteStore::dataHandle(const FieldLocation& fieldLocation, c
     static size_t queueSize = 320;
     std::shared_ptr<MessageQueue> queue = nullptr;
     {
-        std::lock_guard<std::mutex> lock(retrieveMessageMutex_);
+        std::lock_guard lock(messageMutex_);
 
-        auto entry = retrieveMessageQueues_.emplace(id, std::make_shared<MessageQueue>(queueSize));
+        auto entry = messageQueues_.emplace(id, std::make_shared<MessageQueue>(queueSize));
         ASSERT(entry.second);
 
         queue = entry.first->second;

--- a/src/fdb5/remote/client/RemoteStore.h
+++ b/src/fdb5/remote/client/RemoteStore.h
@@ -214,9 +214,8 @@ private:  // members
     // The shared_ptr allows this removal to be asynchronous with the actual task
     // cleaning up and returning to the client.
     std::map<uint32_t, std::shared_ptr<MessageQueue>> messageQueues_;
-    std::map<uint32_t, std::shared_ptr<MessageQueue>> retrieveMessageQueues_;
 
-    std::mutex retrieveMessageMutex_;
+    std::mutex messageMutex_;
 
     Locations locations_;
 };

--- a/src/fdb5/remote/server/CatalogueHandler.cc
+++ b/src/fdb5/remote/server/CatalogueHandler.cc
@@ -526,7 +526,7 @@ void CatalogueHandler::archiveBlob(const uint32_t clientID, const uint32_t reque
         if (it == catalogues_.end()) {
             std::string what("Requested unknown catalogue id: " + std::to_string(clientID));
             error(what, 0, 0);
-            throw;
+            throw SeriousBug(what, Here());
         }
     }
 

--- a/src/fdb5/remote/server/StoreHandler.cc
+++ b/src/fdb5/remote/server/StoreHandler.cc
@@ -10,8 +10,6 @@
 
 #include "fdb5/remote/server/StoreHandler.h"
 
-#include "eckit/exception/Exceptions.h"
-#include "eckit/serialisation/ResizableMemoryStream.h"
 #include "fdb5/LibFdb5.h"
 #include "fdb5/api/helpers/WipeIterator.h"
 #include "fdb5/database/Key.h"
@@ -21,13 +19,12 @@
 #include "fdb5/remote/RemoteFieldLocation.h"
 #include "fdb5/remote/server/ServerConnection.h"
 
-#include "eckit/log/Log.h"
-#include "eckit/serialisation/MemoryStream.h"
-#include "eckit/types/Types.h"
-
 #include "eckit/config/Resource.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/log/Log.h"
 #include "eckit/net/TCPSocket.h"
 #include "eckit/serialisation/MemoryStream.h"
+#include "eckit/serialisation/ResizableMemoryStream.h"
 #include "eckit/types/Types.h"
 #include "eckit/utils/Literals.h"
 
@@ -297,7 +294,7 @@ Store& StoreHandler::getStore(uint32_t clientID) {
             Log::error() << "  clientID: " << kv.first << ", store: " << *(kv.second.store) << std::endl;
         }
         write(Message::Error, true, 0, 0, what.c_str(), what.length());
-        throw;
+        throw SeriousBug(what, Here());
     }
 
     return *(it->second.store);

--- a/tests/fdb/remote/CMakeLists.txt
+++ b/tests/fdb/remote/CMakeLists.txt
@@ -16,18 +16,18 @@ if (HAVE_FDB_BUILD_TOOLS AND HAVE_GRIB)
     ecbuild_configure_file( store.yaml.in store.yaml @ONLY )
     ecbuild_configure_file( client.yaml.in client.yaml @ONLY )
 
-    # ecbuild_add_test(
-    #     TARGET         fdb_test_remote_api
-    #     TYPE           SCRIPT
-    #     COMMAND        ${FDB_TEST_SERVER_SCRIPT}
-    #     ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
-    #     TEST_DEPENDS   fdb_test_remote_api_bin
-    #     ENVIRONMENT    "${test_environment}"
-    #     TEST_PROPERTIES
-    #     TIMEOUT 300
-    #     RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
-    #     LABELS remotefdb
-    # )
+    ecbuild_add_test(
+        TARGET         fdb_test_remote_api
+        TYPE           SCRIPT
+        COMMAND        ${FDB_TEST_SERVER_SCRIPT}
+        ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml catalogue.yaml store.yaml
+        TEST_DEPENDS   fdb_test_remote_api_bin
+        ENVIRONMENT    "${test_environment}"
+        TEST_PROPERTIES
+        TIMEOUT 300
+        RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
+        LABELS remotefdb
+    )
 endif()
 
 add_subdirectory( multi_store )

--- a/tests/fdb/remote/multi_store/CMakeLists.txt
+++ b/tests/fdb/remote/multi_store/CMakeLists.txt
@@ -24,4 +24,20 @@ if (HAVE_FDB_BUILD_TOOLS)
         RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
         LABELS remotefdb
     )
+
+    ecbuild_configure_file( multi_store_tools.sh.in multi_store_tools.sh @ONLY )
+
+    ecbuild_add_test(
+        TARGET         fdb_test_multi_store_tools
+        TYPE           SCRIPT
+        CONDITION      HAVE_GRIB
+        COMMAND        ${CMAKE_CURRENT_BINARY_DIR}/multi_store_tools.sh
+        ARGS           ${CMAKE_CURRENT_BINARY_DIR} client.yaml store1.yaml store2.yaml ${PROJECT_BINARY_DIR}/tests/fdb/od.oper.grib
+        TEST_DEPENDS   fdb_test_multi_store
+        ENVIRONMENT    "${test_environment}"
+        TEST_PROPERTIES
+        TIMEOUT 300
+        RESOURCE_LOCK fdb_remote_tests  # Prevent concurrent runs of remote tests
+        LABELS remotefdb
+    )
 endif()

--- a/tests/fdb/remote/multi_store/multi_store_tools.sh.in
+++ b/tests/fdb/remote/multi_store/multi_store_tools.sh.in
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Exercises the archive -> list -> retrieve workflow via the fdb-write/fdb-list/fdb-read
+# CLI tools (rather than the API, as in test_multi_store.cc) against the same two-store setup.
+
+if [[ $# -lt 5 ]]; then
+    echo "Usage: $0 <test_directory> <client_config> <store1_config> <store2_config> <src_grib_data>" >&2
+    exit 1
+fi
+
+set -ux
+
+testdir=$1
+client_config="$testdir/$2"
+store1_config="$testdir/$3"
+store2_config="$testdir/$4"
+src_data=$5
+catalogue_rootdir=$testdir/catalogue_root
+store1_rootdir=$testdir/store1_root
+store2_rootdir=$testdir/store2_root
+server_pidfile=$testdir/servers.pid
+workdir=$testdir/tools_work
+
+export PATH="@CMAKE_BINARY_DIR@/bin:$PATH"
+
+server="$<TARGET_FILE:fdb-server>"
+fdbwrite="$<TARGET_FILE:fdb-write>"
+fdblist="$<TARGET_FILE:fdb-list>"
+fdbread="$<TARGET_FILE:fdb-read>"
+
+SERVER_LIFETIME=300
+n_dates=8
+
+yell() { printf "$(basename "$0"): \033[0;31m!!! %s !!!\033[0m\n" "$*" >&2; }
+die() { yell "$*"; exit 1; }
+
+line_count() {
+    [[ $# -eq 1 ]] || die "line_count requires 1 argument; expected line count"
+    val=$(wc -l < out) && val=$((val + 0))
+    [[ $val -eq $1 ]] || die "Incorrect count => [$val != $1]"
+}
+
+cleanup() {
+    if [[ -f $server_pidfile ]]; then
+        while read -r SERVER_PID; do
+            kill -TERM "$SERVER_PID" || true
+            sleep 0.2
+            kill -KILL "$SERVER_PID" || true
+        done < "$server_pidfile"
+        rm "$server_pidfile"
+    fi
+
+    rm -rf "$catalogue_rootdir" "$store1_rootdir" "$store2_rootdir" "$workdir"
+}
+
+run_server() {
+  local label="$1"; shift
+  local config="$1"; shift
+  (
+    FDB5_CONFIG_FILE="$config" \
+    FDB_DEBUG=1 \
+    timeout "$SERVER_LIFETIME" "$@" 2>&1 \
+    | awk -v label="$label" -v pidfile="$server_pidfile" '
+        BEGIN { found=0 }
+        {
+          print "[" label "] " $0
+          fflush()
+          if (!found && $0 ~ /pid is [0-9]+/) {
+            pid = $0
+            sub(/.*pid is /, "", pid)
+            sub(/\..*/, "", pid)
+            print pid >> pidfile
+            close(pidfile)
+            found=1
+          }
+        }
+      '
+  ) &
+}
+
+# calls cleanup at exit
+trap cleanup EXIT
+
+cleanup
+mkdir -p "$catalogue_rootdir" "$store1_rootdir" "$store2_rootdir" "$workdir"
+cd "$workdir"
+
+run_server "STORE1" "$store1_config" "$server"
+run_server "STORE2" "$store2_config" "$server"
+
+sleep 0.5
+
+export FDB5_CONFIG_FILE=$client_config
+
+########################################################################################################################
+# Build one archivable message per date; only the "date" key differs between databases, so
+# (per RemoteFDB::storeEndpoint()) each date's database is randomly bound to store1 or store2.
+
+grib_copy -w count=1 "$src_data" base.grib
+read -r base_levtype base_param base_levelist base_step base_time <<< "$(grib_get -p levtype,param,levelist,step,time base.grib)"
+
+dates=()
+for i in $(seq 1 "$n_dates"); do
+    date=$((20250101 + i - 1))
+    dates+=("$date")
+    grib_set -s class=od,expver=xxxx,stream=oper,type=fc,date="$date" base.grib "data.$i.grib"
+done
+
+########################################################################################################################
+# archive
+
+for i in $(seq 1 "$n_dates"); do
+    "$fdbwrite" "data.$i.grib"
+done
+
+########################################################################################################################
+# list: every archived field must be visible through the local catalogue, whichever store backs it
+
+"$fdblist" --all --minimum-keys="" --porcelain | tee out
+line_count "$n_dates"
+
+########################################################################################################################
+# retrieve: sequential, byte-exact per date
+
+for i in $(seq 1 "$n_dates"); do
+    date=${dates[$((i - 1))]}
+    cat > "retrieve.$i.req" <<EOF
+retrieve,
+class=od,
+expver=xxxx,
+stream=oper,
+date=$date,
+time=$base_time,
+domain=g,
+type=fc,
+levtype=$base_levtype,
+step=$base_step,
+levelist=$base_levelist,
+param=$base_param
+EOF
+    "$fdbread" "retrieve.$i.req" "seq.$i.grib"
+    cmp "seq.$i.grib" "data.$i.grib"
+done
+
+########################################################################################################################
+# retrieve: concurrently, one client process per date plus one request spanning every date
+
+date_list=$(IFS=/; echo "${dates[*]}")
+cat > retrieve.all.req <<EOF
+retrieve,
+class=od,
+expver=xxxx,
+stream=oper,
+date=$date_list,
+time=$base_time,
+domain=g,
+type=fc,
+levtype=$base_levtype,
+step=$base_step,
+levelist=$base_levelist,
+param=$base_param
+EOF
+
+pids=()
+for i in $(seq 1 "$n_dates"); do
+    "$fdbread" "retrieve.$i.req" "conc.$i.grib" &
+    pids+=("$!")
+done
+"$fdbread" retrieve.all.req conc.all.grib &
+pids+=("$!")
+
+status=0
+for pid in "${pids[@]}"; do
+    wait "$pid" || status=1
+done
+[[ $status -eq 0 ]] || die "One or more concurrent fdb-read invocations failed"
+
+for i in $(seq 1 "$n_dates"); do
+    cmp "conc.$i.grib" "data.$i.grib"
+done
+
+count=$(codes_count conc.all.grib)
+[[ $count -eq $n_dates ]] || die "Incorrect message count in combined retrieve => [$count != $n_dates]"
+
+exit 0

--- a/tests/fdb/remote/multi_store/multi_store_tools.sh.in
+++ b/tests/fdb/remote/multi_store/multi_store_tools.sh.in
@@ -8,7 +8,7 @@ if [[ $# -lt 5 ]]; then
     exit 1
 fi
 
-set -ux
+set -eux
 
 testdir=$1
 client_config="$testdir/$2"

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -36,7 +36,7 @@ if (HAVE_FDB_BUILD_TOOLS) # test scripts use the fdb tools
         
         if (HAVE_GRIB)
             add_subdirectory(FDB-610)
-            # add_subdirectory(FDB-491)
+            add_subdirectory(FDB-491)
             add_subdirectory(FDB-595)
         endif()
 

--- a/tests/regressions/FDB-595/FDB-595.sh.in
+++ b/tests/regressions/FDB-595/FDB-595.sh.in
@@ -34,7 +34,8 @@ EOF
 
 cleanup() {
     local exit_code=$?
-    kill -9 "$catal_pid" "$store_pid" 2>/dev/null || true
+    [[ -n ${catal_pid-} ]] && kill -9 "$catal_pid" 2>/dev/null || true
+    [[ -n ${store_pid-} ]] && kill -9 "$store_pid" 2>/dev/null || true
     exit $exit_code
 }
 trap cleanup SIGINT SIGTERM EXIT

--- a/tests/regressions/FDB-595/FDB-595.sh.in
+++ b/tests/regressions/FDB-595/FDB-595.sh.in
@@ -32,6 +32,13 @@ cat > list <<EOF
 {class=od,expver=0001,stream=oper,date=20251125,time=0000,domain=g}{type=fc,levtype=pl}{step=0,levelist=1000,param=130}
 EOF
 
+cleanup() {
+    local exit_code=$?
+    kill -9 "$catal_pid" "$store_pid" 2>/dev/null || true
+    exit $exit_code
+}
+trap cleanup SIGINT SIGTERM EXIT
+
 FDB5_CONFIG_FILE=$bindir/catalogue.yaml $fdbserver &
 catal_pid=$!
 
@@ -41,8 +48,5 @@ store_pid=$!
 FDB5_CONFIG_FILE=$bindir/client.yaml $fdbwrite levtypes.grib
 
 FDB5_CONFIG_FILE=$bindir/client.yaml $fdblist --all --minimum-keys="" --porcelain | tee out
-
-kill -9 $catal_pid
-kill -9 $store_pid
 
 cmp out list

--- a/tests/regressions/FDB-610/FDB-610.sh.in
+++ b/tests/regressions/FDB-610/FDB-610.sh.in
@@ -14,7 +14,7 @@ export FDB_DEBUG=1
 cleanup() {
     local exit_code=$?
     echo "Shutting down..."
-    kill $PID_STORE $PID_CATALOGUE 2>/dev/null || true
+    kill -9 $PID_STORE $PID_CATALOGUE 2>/dev/null || true
     exit $exit_code
 }
 trap cleanup SIGINT SIGTERM EXIT


### PR DESCRIPTION
### Description

This PR focuses on making remote client/server teardown more robust in FDB5 remote mode, reducing shutdown races and improving failure behaviour when remote connections drop, alongside expanding remote multi-store test coverage.

Changes:

Make teardown and deregistration paths more robust/idemponent across remote Connection, Client, RemoteStore, RemoteCatalogue, and RemoteFDB, and ensure pending requests fail promptly on connection loss.
Replace std::rand() endpoint selection with per-thread std::mt19937-based selection in remote routing/endpoint choice.
Add a new CLI-tools-based remote multi-store workflow test and adjust regression test teardown scripts.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-323
<!-- PREVIEW-PUBLISH-FDB_END -->