### PR TITLE
cmake: pin python to build-time interpreter for editable installs

### DIFF
--- a/cmake/pyfdb_setup.py.in
+++ b/cmake/pyfdb_setup.py.in
@@ -11,8 +11,15 @@ version_suffix = os.environ.get("VERSION_SUFFIX", "")
 if version_suffix:
     version_suffix = f".{version_suffix}"
     requires_extra = [f"fdb5lib==@fdb5_VERSION_STR@{version_suffix}"]
+    # Published wheels are binary and platform/version specific, but pip already
+    # enforces this via the wheel's compiled tag, so keep a broad requirement here.
+    python_requires = ">3.10"
 else:
     requires_extra = []
+    # This project is only meant to be installed editably from the build tree
+    # that generated it, so pin it to the exact Python version cmake was run
+    # with (the one the compiled extension modules were built against).
+    python_requires = "==@Python_VERSION_MAJOR@.@Python_VERSION_MINOR@.*"
 
 
 # NOTE see ci-utils/wheelmaker/buildscripts/setup_utils, we need to get the right abi compat tag
@@ -39,7 +46,7 @@ setup(
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",
     install_requires=["findlibs>=0.1.2", "PyYAML>=6.0.3"] + requires_extra,
-    python_requires=">3.10",
+    python_requires=python_requires,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/cmake/z3fdb_setup.py.in
+++ b/cmake/z3fdb_setup.py.in
@@ -13,8 +13,15 @@ version_suffix = os.environ.get("VERSION_SUFFIX", "")
 if version_suffix:
     version_suffix = f".{version_suffix}"
     requires_extra = [f"fdb5lib==@fdb5_VERSION_STR@{version_suffix}"]
+    # Published wheels are binary and platform/version specific, but pip already
+    # enforces this via the wheel's compiled tag, so keep a broad requirement here.
+    python_requires = ">3.10"
 else:
     requires_extra = []
+    # This project is only meant to be installed editably from the build tree
+    # that generated it, so pin it to the exact Python version cmake was run
+    # with (the one the compiled extension modules were built against).
+    python_requires = "==@Python_VERSION_MAJOR@.@Python_VERSION_MINOR@.*"
 
 
 # NOTE see ci-utils/wheelmaker/buildscripts/setup_utils, we need to get the right abi compat tag
@@ -46,8 +53,6 @@ setup(
     license_files=["LICENSE"],
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    install_requires=["numpy", "zarr==3.1.6", "findlibs>=0.1.2"] + requires_extra,
-    python_requires=">=3.11",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -60,6 +65,8 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries",
     ],
+    install_requires=["numpy", "zarr==3.1.6", "findlibs>=0.1.2"] + requires_extra,
+    python_requires=python_requires,
     has_ext_modules=lambda: True,
     **ext_kwargs[sys.platform],
 )


### PR DESCRIPTION
The generated setup.py files for pyfdb and z3fdb are used both to build binary wheels and to allow editable installs directly from the build staging directory. Wheels already carry a python-version-specific tag enforced by pip, but the editable install path had no such protection: nothing prevented 'pip install -e' from succeeding under a different Python version than the one that built the compiled extension modules.

Use the VERSION_SUFFIX env var (already used to distinguish CD/publish builds from local dev builds) to pick the right python_requires:
  - VERSION_SUFFIX set (publish build, wheel path): keep the existing broad '>3.10' requirement.
  - VERSION_SUFFIX unset (local dev build, editable install path): pin python_requires to the exact major.minor of the Python cmake found via find_package(Python ...), using @Python_VERSION_MAJOR@ and @Python_VERSION_MINOR@ which are substituted at configure_file time.


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-325
<!-- PREVIEW-PUBLISH-FDB_END -->