### PR TITLE
FDB-735 reading overlay subtoc, do not check the current directory 

### DIFF
--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -689,6 +689,9 @@ eckit::LocalPathName TocHandler::parseSubTocRecord(const TocRecord& r, bool read
                 absPath = currentDirectory() / path.baseName();
             }
             else {
+                eckit::Log::error()
+                    << "Skipping an FDB overlay database that is no longer available. Original path was: " << path
+                    << std::endl;
                 absPath = "";
             }
         }

--- a/src/fdb5/toc/TocHandler.cc
+++ b/src/fdb5/toc/TocHandler.cc
@@ -674,6 +674,7 @@ eckit::LocalPathName TocHandler::parseSubTocRecord(const TocRecord& r, bool read
     eckit::MemoryStream s(&r.payload_[0], r.maxPayloadSize);
     eckit::LocalPathName path;
     s >> path;
+
     // Handle both path and absPath for compatibility as we move from storing
     // absolute paths to relative paths. Either may exist in either the TOC_SUB_TOC
     // or TOC_CLEAR entries.
@@ -682,7 +683,14 @@ eckit::LocalPathName TocHandler::parseSubTocRecord(const TocRecord& r, bool read
     if (path.path()[0] == '/') {
         absPath = findRealPath(path);
         if (!absPath.exists()) {
-            absPath = currentDirectory() / path.baseName();
+            // the DB may have been moved, so try to find the subtoc in the current directory
+            // except in case of an overlay (subtoc name = "toc")
+            if (path.baseName() != "toc") {
+                absPath = currentDirectory() / path.baseName();
+            }
+            else {
+                absPath = "";
+            }
         }
     }
     else {

--- a/tests/fdb/api/test_auxiliary.cc
+++ b/tests/fdb/api/test_auxiliary.cc
@@ -199,7 +199,7 @@ CASE("Ensure wipe fails if extensions are unknown") {
         auto iter = fdb.wipe(request, doit, false, unsafeWipeAll);
         while (iter.next(elem)) {}
     }
-    catch (eckit::Exception) {
+    catch (eckit::Exception&) {
         error_was_thrown = true;
     }
     EXPECT(error_was_thrown);

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -32,6 +32,7 @@ if (HAVE_FDB_BUILD_TOOLS) # test scripts use the fdb tools
     endif()
 
     add_subdirectory(FDB-241)
+    add_subdirectory(FDB-735)
 
     if (HAVE_FDB_REMOTE)
         add_subdirectory(FDB-419)

--- a/tests/regressions/FDB-735/CMakeLists.txt
+++ b/tests/regressions/FDB-735/CMakeLists.txt
@@ -1,0 +1,5 @@
+ecbuild_configure_file( FDB-735.sh.in FDB-735.sh @ONLY )
+ecbuild_add_test(
+    TYPE     SCRIPT
+    COMMAND  FDB-735.sh
+    ENVIRONMENT "${test_environment}" )

--- a/tests/regressions/FDB-735/FDB-735.sh.in
+++ b/tests/regressions/FDB-735/FDB-735.sh.in
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# A 'type: select' FDB whose lanes share the same physical root can, for a
+# partial (ambiguous) list/wipe request that omits the keyword used to
+# discriminate between lanes, have every matching lane independently
+# rediscover the *same* on-disk catalogue and process it more than once.
+#
+# Two lanes ("stream=oper" and "stream=dcda") share the same root.
+# A request that omits "stream" entirely legitimately matches both lanes
+# (SelectFDB's MatchOnMissing policy), so both are queried -- but each lane
+# then scans the *shared* root and finds *both* catalogues (the per-lane
+# selector is not used to filter which catalogues are relevant), so every
+# catalogue is reported/wiped once per lane instead of once overall.
+
+set -euxo pipefail
+
+yell() { printf "$(basename "$0"): \033[0;31m!!! %s !!!\033[0m\\n" "$*" >&2; }
+die() { yell "$*"; exit 1; }
+
+fdbroot="$<TARGET_FILE:fdb-root>"
+fdboverlay="$<TARGET_FILE:fdb-overlay>"
+fdbwipe="$<TARGET_FILE:fdb-wipe>"
+
+srcdir=@CMAKE_CURRENT_SOURCE_DIR@
+bindir=@CMAKE_CURRENT_BINARY_DIR@
+wdir=$bindir/FDB-735
+
+### cleanup and prepare test
+
+rm -rf "$wdir"
+mkdir -p "$wdir/etc/fdb"
+mkdir -p "$wdir/root"
+
+cd "$wdir"
+
+for f in config.yaml schema
+do
+    cp "$srcdir/$f" "$wdir/etc/fdb"
+done
+
+export FDB_HOME="$wdir"
+unset FDB5_CONFIG_FILE
+unset FDB_CONFIG_FILE
+
+# create empty expver 1234
+$fdbroot class=od,expver=1234,stream=oper,domain=g,date=-1,time=0 --create
+
+# overlay 1235 --> 1234
+$fdboverlay class=od,expver=1234,stream=oper,domain=g,date=-1,time=0 class=od,expver=1235,stream=oper,domain=g,date=-1,time=0 
+
+# remove 1234 (dangerous, since we have an overlay!)
+$fdbwipe class=od,expver=1234,stream=oper,domain=g,date=-1,time=0 --doit
+
+# segfault while removing 1235
+$fdbwipe class=od,expver=1235,stream=oper,domain=g,date=-1,time=0
+

--- a/tests/regressions/FDB-735/config.yaml
+++ b/tests/regressions/FDB-735/config.yaml
@@ -1,0 +1,8 @@
+---
+type: local
+schema: ~fdb/etc/fdb/schema
+engine: toc
+spaces:
+- handler: Default
+  roots:
+  - path: ./root

--- a/tests/regressions/FDB-735/schema
+++ b/tests/regressions/FDB-735/schema
@@ -1,0 +1,12 @@
+
+param:      Param;
+step:       Step;
+date:       Date;
+levelist:   Double;
+expver:     Expver;
+time:       Time;
+
+[ class, expver, stream, date, time, domain
+       [ type, levtype
+               [ step, levelist, param ]]
+]


### PR DESCRIPTION
### Description

reading a subtoc of a moved DB, if the subtoc file is stored with an absolute path, it might appear as not existing.
in that scenario, we look for it in the current directory

in case of FDB overlays, we use the subtoc mechanism to record the referred FDB database
In this case, we should not look into the current directory (infinite loop)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-338
<!-- PREVIEW-PUBLISH-FDB_END -->