### PR TITLE
FDB-739 fix SelectFDB config (userConfig, callback)

### DIFF
--- a/src/fdb5/api/FDBFactory.cc
+++ b/src/fdb5/api/FDBFactory.cc
@@ -62,11 +62,11 @@ bool FDBBase::enabled(const ControlIdentifier& controlIdentifier) const {
 }
 
 void FDBBase::registerFlushCallback(FlushCallback callback) {
-    callbacks_->flushCallback_ = callback;
+    callbacks_->flushCallback_ = std::move(callback);
 }
 
 void FDBBase::registerArchiveCallback(ArchiveCallback callback) {
-    callbacks_->archiveCallback_ = callback;
+    callbacks_->archiveCallback_ = std::move(callback);
 }
 
 void FDBBase::setCallbacks(std::shared_ptr<Callbacks> callbacks) {

--- a/src/fdb5/api/FDBFactory.cc
+++ b/src/fdb5/api/FDBFactory.cc
@@ -28,7 +28,8 @@ namespace fdb5 {
 //----------------------------------------------------------------------------------------------------------------------
 
 
-FDBBase::FDBBase(const Config& config, const std::string& name) : name_(name), config_(config) {
+FDBBase::FDBBase(const Config& config, const std::string& name) :
+    name_(name), config_(config), callbacks_(std::make_shared<Callbacks>()) {
 
     bool writable = config.getBool("writable", true);
     bool visitable = config.getBool("visitable", true);
@@ -58,6 +59,19 @@ const Config& FDBBase::config() const {
 
 bool FDBBase::enabled(const ControlIdentifier& controlIdentifier) const {
     return controlIdentifiers_.enabled(controlIdentifier);
+}
+
+void FDBBase::registerFlushCallback(FlushCallback callback) {
+    callbacks_->flushCallback_ = callback;
+}
+
+void FDBBase::registerArchiveCallback(ArchiveCallback callback) {
+    callbacks_->archiveCallback_ = callback;
+}
+
+void FDBBase::setCallbacks(std::shared_ptr<Callbacks> callbacks) {
+    ASSERT(callbacks);
+    callbacks_ = std::move(callbacks);
 }
 
 FDBFactory& FDBFactory::instance() {

--- a/src/fdb5/api/FDBFactory.h
+++ b/src/fdb5/api/FDBFactory.h
@@ -107,6 +107,12 @@ public:  // methods
 
     bool enabled(const ControlIdentifier& controlIdentifier) const;
 
+    void registerFlushCallback(FlushCallback callback) override;
+    void registerArchiveCallback(ArchiveCallback callback) override;
+
+    /// Share a callback registry with this FDB, so that callbacks registered on an owning FDB are seen here.
+    virtual void setCallbacks(std::shared_ptr<Callbacks> callbacks);
+
 private:  // methods
 
     virtual void print(std::ostream& s) const = 0;
@@ -123,6 +129,9 @@ protected:  // members
     Config config_;
 
     ControlIdentifiers controlIdentifiers_;
+
+    /// Never null. Shared with the owning FDB, if any.
+    std::shared_ptr<Callbacks> callbacks_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/api/LocalFDB.cc
+++ b/src/fdb5/api/LocalFDB.cc
@@ -67,7 +67,7 @@ void LocalFDB::archive(const Key& key, const void* data, size_t length) {
         std::lock_guard lock(mutex_);
         if (!archiver_) {
             LOG_DEBUG_LIB(LibFdb5) << *this << ": Constructing new archiver" << std::endl;
-            archiver_ = std::make_unique<Archiver>(config_, archiveCallback_);
+            archiver_ = std::make_unique<Archiver>(config_, callbacks_->archiveCallback_);
         }
         archiver = archiver_.get();
     }
@@ -172,11 +172,11 @@ void LocalFDB::flush() {
     }
     if (archiver) {
         archiver->flush();
-        flushCallback_();
+        callbacks_->flushCallback_();
     }
     else if (reindexer) {
         reindexer->flush();
-        flushCallback_();
+        callbacks_->flushCallback_();
     }
 }
 

--- a/src/fdb5/api/SelectFDB.cc
+++ b/src/fdb5/api/SelectFDB.cc
@@ -43,7 +43,9 @@ static FDBBuilder<SelectFDB> selectFdbBuilder("select");
 
 //----------------------------------------------------------------------------------------------------------------------
 
-SelectFDB::FDBLane::FDBLane(const eckit::LocalConfiguration& config) : config_(config), fdb_(nullptr) {
+SelectFDB::FDBLane::FDBLane(const eckit::LocalConfiguration& config, const eckit::Configuration& userConfig,
+                            std::shared_ptr<Callbacks> callbacks) :
+    config_(config, userConfig), fdb_(nullptr), callbacks_(callbacks) {
     config_.setMatcher(std::make_unique<SelectMatcher>(config));
 }
 
@@ -56,6 +58,7 @@ bool SelectFDB::FDBLane::matches(const T& vals, Matcher::MatchMissingPolicy matc
 FDBBase& SelectFDB::FDBLane::get() {
     if (!fdb_) {
         fdb_ = FDBFactory::instance().build(config_);
+        fdb_->setCallbacks(callbacks_);
     }
     return *fdb_;
 }
@@ -63,6 +66,13 @@ FDBBase& SelectFDB::FDBLane::get() {
 void SelectFDB::FDBLane::flush() {
     if (fdb_) {
         fdb_->flush();
+    }
+}
+
+void SelectFDB::FDBLane::setCallbacks(std::shared_ptr<Callbacks> callbacks) {
+    callbacks_ = std::move(callbacks);
+    if (fdb_) {
+        fdb_->setCallbacks(callbacks_);
     }
 }
 
@@ -84,7 +94,7 @@ SelectFDB::SelectFDB(const Config& config, const std::string& name) : FDBBase(co
         if (!schema.empty() && !c.has("schema")) {
             c.set("schema", schema);
         }
-        subFdbs_.emplace_back(FDBLane{c});
+        subFdbs_.emplace_back(FDBLane{c, config.userConfig(), callbacks_});
     }
 }
 
@@ -192,6 +202,12 @@ void SelectFDB::flush() {
     }
 }
 
+void SelectFDB::setCallbacks(std::shared_ptr<Callbacks> callbacks) {
+    FDBBase::setCallbacks(callbacks);
+    for (auto& lane : subFdbs_) {
+        lane.setCallbacks(callbacks_);
+    }
+}
 
 void SelectFDB::print(std::ostream& s) const {
     s << "SelectFDB()";

--- a/src/fdb5/api/SelectFDB.h
+++ b/src/fdb5/api/SelectFDB.h
@@ -31,6 +31,7 @@
 namespace fdb5 {
 
 //----------------------------------------------------------------------------------------------------------------------
+
 class SelectFDB : public FDBBase {
 
 private:  // types
@@ -38,19 +39,22 @@ private:  // types
     class FDBLane {
         Config config_;
         std::shared_ptr<FDBBase> fdb_;
+        std::shared_ptr<Callbacks> callbacks_;
 
     public:
 
-        FDBLane(const eckit::LocalConfiguration& config);
+        FDBLane(const eckit::LocalConfiguration& config, const eckit::Configuration& userConfig,
+                std::shared_ptr<Callbacks> callbacks);
 
         FDBBase& get();
 
         void flush();
 
+        void setCallbacks(std::shared_ptr<Callbacks> callbacks);
+
         template <typename T>  // T is either a mars request or a Key
         bool matches(const T& vals, metkit::mars::Matcher::MatchMissingPolicy matchOnMissing) const;
     };
-
 
 public:  // methods
 
@@ -82,6 +86,8 @@ public:  // methods
     AxesIterator axesIterator(const FDBToolRequest& request, int level) override;
 
     void flush() override;
+
+    void setCallbacks(std::shared_ptr<Callbacks> callbacks) override;
 
 private:  // methods
 

--- a/src/fdb5/api/helpers/Callback.h
+++ b/src/fdb5/api/helpers/Callback.h
@@ -34,17 +34,19 @@ static const ConstructorCallback CALLBACK_CONSTRUCTOR_NOOP = [](auto&&...) {};
 
 // -------------------------------------------------------------------------------------------------
 
+struct Callbacks {
+    FlushCallback flushCallback_ = CALLBACK_FLUSH_NOOP;
+    ArchiveCallback archiveCallback_ = CALLBACK_ARCHIVE_NOOP;
+};
+
 // This class provides a common interface for registering callbacks with an FDB object or a Store/Catalogue Handler.
 class CallbackRegistry {
 public:
 
-    void registerFlushCallback(FlushCallback callback) { flushCallback_ = callback; }
-    void registerArchiveCallback(ArchiveCallback callback) { archiveCallback_ = callback; }
+    virtual ~CallbackRegistry() = default;
 
-protected:
-
-    FlushCallback flushCallback_ = CALLBACK_FLUSH_NOOP;
-    ArchiveCallback archiveCallback_ = CALLBACK_ARCHIVE_NOOP;
+    virtual void registerFlushCallback(FlushCallback callback) = 0;
+    virtual void registerArchiveCallback(ArchiveCallback callback) = 0;
 };
 
 }  // namespace fdb5

--- a/src/fdb5/config/Config.cc
+++ b/src/fdb5/config/Config.cc
@@ -56,7 +56,7 @@ Config::Config(const Configuration& config, const eckit::Configuration& userConf
 }
 
 Config::Config(const Config& other) :
-    LocalConfiguration(other), schemaPathInitialised_(false), matcher_(other.matcher_), userConfig_(other.userConfig_) {
+    LocalConfiguration(other), schemaPathInitialised_(false), userConfig_(other.userConfig_), matcher_(other.matcher_) {
     std::lock_guard lock(other.schemaMutex_);
     schemaPath_ = other.schemaPath_;
     schemaPathInitialised_ = other.schemaPathInitialised_;

--- a/src/fdb5/remote/server/StoreHandler.cc
+++ b/src/fdb5/remote/server/StoreHandler.cc
@@ -236,7 +236,7 @@ void StoreHandler::archiveBlob(const uint32_t clientID, const uint32_t requestID
 
     const Key fullkey(dict);  /// @note: we do not have the third level of the key.
 
-    archiveCallback_(fullkey, charData + s.position(), length - s.position(), promise.get_future());
+    callbacks_.archiveCallback_(fullkey, charData + s.position(), length - s.position(), promise.get_future());
 
     Log::status() << "Archiving done: " << ss_key.str() << std::endl;
 
@@ -265,7 +265,7 @@ void StoreHandler::flush(uint32_t clientID, uint32_t requestID, const eckit::Buf
         ASSERT(it != stores_.end());
         it->second.store->flush();
 
-        flushCallback_();
+        callbacks_.flushCallback_();
     }
 
     Log::info() << "Flush complete" << std::endl;
@@ -497,6 +497,14 @@ void StoreHandler::finaliseWipeState(const uint32_t clientID, const uint32_t req
     if (doit) {
         wipesInProgress_.emplace(dbkey, WipeInProgress{unsafeAll, std::move(storeState)});
     }
+}
+
+void StoreHandler::registerFlushCallback(FlushCallback callback) {
+    callbacks_.flushCallback_ = callback;
+}
+
+void StoreHandler::registerArchiveCallback(ArchiveCallback callback) {
+    callbacks_.archiveCallback_ = callback;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/server/StoreHandler.cc
+++ b/src/fdb5/remote/server/StoreHandler.cc
@@ -500,11 +500,11 @@ void StoreHandler::finaliseWipeState(const uint32_t clientID, const uint32_t req
 }
 
 void StoreHandler::registerFlushCallback(FlushCallback callback) {
-    callbacks_.flushCallback_ = callback;
+    callbacks_.flushCallback_ = std::move(callback);
 }
 
 void StoreHandler::registerArchiveCallback(ArchiveCallback callback) {
-    callbacks_.archiveCallback_ = callback;
+    callbacks_.archiveCallback_ = std::move(callback);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/remote/server/StoreHandler.h
+++ b/src/fdb5/remote/server/StoreHandler.h
@@ -62,6 +62,9 @@ private:  // methods
     Store& store(uint32_t clientID, const Key& dbKey);
     Store& getStore(uint32_t clientID, const eckit::URI& uri);
 
+    void registerFlushCallback(FlushCallback callback) override;
+    void registerArchiveCallback(ArchiveCallback callback) override;
+
 private:  // members
 
     struct StoreHelper;
@@ -74,6 +77,8 @@ private:  // members
     };
 
     std::map<Key, WipeInProgress> wipesInProgress_;
+
+    Callbacks callbacks_;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fdb5/rules/SelectMatcher.cc
+++ b/src/fdb5/rules/SelectMatcher.cc
@@ -16,7 +16,11 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <sstream>
 #include <string>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
 
 #include "metkit/mars/Parameter.h"
 
@@ -48,13 +52,22 @@ private:
 
 // ------------------------------------------------------------------------------------------------------
 
-SelectMatcher::SelectMatcher(const eckit::LocalConfiguration& config) :
-    select_{Matcher(config.getString("select", ""), Matcher::Policy::Any)} {
-
+SelectMatcher::SelectMatcher(const eckit::LocalConfiguration& config) {
+    bool found = false;
+    if (config.has("select")) {
+        select_ = Matcher(config.getString("select"), Matcher::Policy::Any);
+        found = true;
+    }
     if (config.has("excludes")) {
         for (const auto& ex : config.getStringVector("excludes")) {
             excludes_.push_back(Matcher(ex, Matcher::Policy::All));
         }
+        found = true;
+    }
+    if (!found) {
+        std::ostringstream ss;
+        ss << "SelectMatcher: no select or excludes rule found in config: " << config;
+        throw eckit::BadValue(ss.str(), Here());
     }
 }
 
@@ -71,7 +84,7 @@ bool SelectMatcher::match(const metkit::mars::MarsRequest& request, Matcher::Mat
 
 template <typename T>  // T is either a MarsRequest or KeyAccessor
 bool SelectMatcher::matchInner(const T& vals, Matcher::MatchMissingPolicy matchOnMissing) const {
-    if (!select_.match(vals, matchOnMissing)) {
+    if (select_ && !select_->match(vals, matchOnMissing)) {
         return false;
     }
 

--- a/src/fdb5/rules/SelectMatcher.h
+++ b/src/fdb5/rules/SelectMatcher.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
@@ -46,8 +47,8 @@ private:
 
 private:
 
-    Matcher select_;
-    std::vector<Matcher> excludes_;
+    std::optional<Matcher> select_{std::nullopt};
+    std::vector<Matcher> excludes_{};
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/fdb/api/ApiSpy.h
+++ b/tests/fdb/api/ApiSpy.h
@@ -18,6 +18,7 @@
 #ifndef fdb_testing_ApiSpy_H
 #define fdb_testing_ApiSpy_H
 
+#include <future>
 #include <tuple>
 #include <vector>
 
@@ -89,6 +90,9 @@ public:  // methods
     void archive(const fdb5::Key& key, const void* data, size_t length) override {
         counts_.archive += 1;
         archives_.push_back(std::make_tuple(key, data, length));
+        std::promise<std::shared_ptr<const fdb5::FieldLocation>> promise;
+        promise.set_value(nullptr);
+        callbacks_->archiveCallback_(key, data, length, promise.get_future());
     }
 
     fdb5::ListIterator inspect(const metkit::mars::MarsRequest& request) override {
@@ -145,7 +149,10 @@ public:  // methods
         return fdb5::StatusIterator(0);
     }
 
-    void flush() override { counts_.flush += 1; }
+    void flush() override {
+        counts_.flush += 1;
+        callbacks_->flushCallback_();
+    }
 
     // For diagnostics
 

--- a/tests/fdb/api/test_select.cc
+++ b/tests/fdb/api/test_select.cc
@@ -14,6 +14,8 @@
  */
 
 #include <cstdlib>
+#include <future>
+#include <memory>
 
 #include "eckit/testing/Test.h"
 
@@ -32,8 +34,7 @@ using namespace eckit::testing;
 using namespace eckit;
 
 
-namespace fdb {
-namespace test {
+namespace fdb::test {
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -744,8 +745,88 @@ CASE("control_distributed_according_to_select") {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace fdb
+fdb5::Config nestedConfig() {
+
+    // A selectFDB whose 'rd' lane is itself a selectFDB
+
+    LocalConfiguration cfg_od;
+    cfg_od.set("type", "spy");
+    cfg_od.set("select", "class=od");
+
+    LocalConfiguration cfg_rd1;
+    cfg_rd1.set("type", "spy");
+    cfg_rd1.set("select", "class=rd,expver=xx.?.?");
+
+    LocalConfiguration cfg_rd2;
+    cfg_rd2.set("type", "spy");
+    cfg_rd2.set("select", "class=rd,expver=yy.?.?");
+
+    LocalConfiguration cfg_rd;
+    cfg_rd.set("type", "select");
+    cfg_rd.set("select", "class=rd");
+    cfg_rd.set("fdbs", {cfg_rd1, cfg_rd2});
+
+    fdb5::Config cfg;
+    cfg.set("type", "select");
+    cfg.set("fdbs", {cfg_od, cfg_rd});
+
+    return cfg;
+}
+
+
+CASE("user_config_reaches_sub_fdbs") {
+
+    ApiSpy::knownSpies().clear();
+
+    LocalConfiguration userConfig;
+    userConfig.set("useSubToc", true);
+
+    fdb5::FDB fdb(fdb5::Config(nestedConfig(), userConfig));
+
+    fdb5::Key k;
+    k.set("class", "rd");
+    k.set("expver", "yyyy");
+    fdb.archive(k, (const void*)0x4321, 4321);
+
+    EXPECT_EQUAL(ApiSpy::knownSpies().size(), 1);
+    EXPECT(ApiSpy::knownSpies()[0]->config().userConfig().getBool("useSubToc", false));
+}
+
+
+CASE("callbacks_reach_nested_sub_fdbs") {
+
+    ApiSpy::knownSpies().clear();
+
+    fdb5::FDB fdb(nestedConfig());
+
+    size_t archiveCalls = 0;
+    size_t flushCalls = 0;
+
+    fdb.registerArchiveCallback(
+        [&archiveCalls](const fdb5::Key&, const void*, size_t,
+                        std::future<std::shared_ptr<const fdb5::FieldLocation>>) { archiveCalls += 1; });
+    fdb.registerFlushCallback([&flushCalls] { flushCalls += 1; });
+
+    fdb5::Key k;
+    k.set("class", "od");
+    k.set("expver", "xxxx");
+    fdb.archive(k, (const void*)0x1234, 1234);
+
+    // second level of nesting
+    k.set("class", "rd");
+    k.set("expver", "yyyy");
+    fdb.archive(k, (const void*)0x4321, 4321);
+
+    EXPECT_EQUAL(ApiSpy::knownSpies().size(), 2);
+    EXPECT_EQUAL(archiveCalls, 2);
+
+    fdb.flush();
+    EXPECT_EQUAL(flushCalls, 2);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace fdb::test
 
 int main(int argc, char** argv) {
     return run_tests(argc, argv);

--- a/tests/fdb/etc/fdb/config.yaml
+++ b/tests/fdb/etc/fdb/config.yaml
@@ -1,15 +1,26 @@
 ---
-type: local
-engine: toc
-schema: @PROJECT_BINARY_DIR@/etc/fdb/schema
-spaces:
-- handler: Default
-  roots:
-  - path: @PROJECT_BINARY_DIR@/tests/fdb/root
-    writable: true
-    visit: true
-  - path: @PROJECT_BINARY_DIR@/tests/fdb/root2
-    wipe: true
-    archive: false
-    list: true
-    retrieve: true
+type: select
+fdbs:
+- select: class=rd
+  type: local
+  engine: toc
+  schema: @PROJECT_BINARY_DIR@/etc/fdb/schema
+  spaces:
+  - handler: Default
+    roots:
+    - path: @PROJECT_BINARY_DIR@/tests/fdb/root
+- excludes: [class=rd]
+  type: local
+  engine: toc
+  schema: @PROJECT_BINARY_DIR@/etc/fdb/schema
+  spaces:
+  - handler: Default
+    roots:
+    - path: @PROJECT_BINARY_DIR@/tests/fdb/root
+      writable: true
+      visit: true
+    - path: @PROJECT_BINARY_DIR@/tests/fdb/root2
+      wipe: true
+      archive: false
+      list: true
+      retrieve: true

--- a/tests/fdb/test_service.cc
+++ b/tests/fdb/test_service.cc
@@ -71,7 +71,7 @@ struct FixtureService {
         modelParams_.push_back("138");
     }
 
-    void write_cycle(fdb5::Archiver& fdb, StringDict& p) {
+    void write_cycle(fdb5::FDB& fdb, StringDict& p) {
         Translator<size_t, std::string> str;
         for (const auto& param : modelParams_) {
             p["param"] = param;
@@ -90,9 +90,7 @@ struct FixtureService {
                     std::string data_str = data.str();
 
                     fdb5::Key k{p};
-                    auto visitor =
-                        ArchiveVisitor::create(fdb, k, static_cast<const void*>(data_str.c_str()), data_str.size());
-                    fdb.archive(k, *visitor);
+                    fdb.archive(k, static_cast<const void*>(data_str.c_str()), data_str.size());
                 }
             }
         }
@@ -210,7 +208,7 @@ CASE("test_fdb_service") {
         FixtureService f;
 
         SECTION("test_fdb_service_write") {
-            fdb5::Archiver fdb;
+            fdb5::FDB fdb;
 
             f.p["class"] = "rd";
             f.p["stream"] = "oper";
@@ -387,7 +385,7 @@ CASE("test_fdb_service_subtoc") {
         fdb5::Config config(expanded, userConf);
 
         SECTION("test_fdb_service_subtoc_write") {
-            fdb5::Archiver fdb(config);
+            fdb5::FDB fdb(config);
 
             f.p["class"] = "rd";
             f.p["stream"] = "oper";

--- a/tests/fdb/type/test_toKey.cc
+++ b/tests/fdb/type/test_toKey.cc
@@ -26,6 +26,15 @@ using namespace eckit;
 
 namespace fdb::test {
 
+const std::string config_str(R"XX(
+type: local
+engine: toc
+schema: ~fdb/etc/fdb/schema
+spaces:
+- roots:
+    - path: ~fdb/tests/fdb/root
+)XX");
+
 fdb5::Config config;
 
 char data[4];
@@ -131,7 +140,8 @@ CASE("Step & ClimateDaily - expansion") {
         EXPECT_EQUAL(key.valuesToString(), "20210427:dacl:0000:ei:7799:g:pb:pl:2-12:99:100:50:129.128");
     }
 
-    fdb5::Config conf = config.expandConfig();
+    eckit::testing::SetEnv env("FDB_CONFIG", config_str.c_str());
+    fdb5::Config conf = fdb5::Config().expandConfig();
     fdb5::Archiver archiver(conf);
     auto visitor = fdb5::ArchiveVisitor::create(archiver, key, data, 4);
     config.schema().expand(key, *visitor);
@@ -267,7 +277,9 @@ CASE("Expver, Time & ClimateDaily - string ctor - expansion") {
     EXPECT_EQUAL(key.valuesToString(), "ei:0001:dacl:g:pb:pl:20210427:0600:0:99:100:50:129.128");
 
     {
-        fdb5::Archiver archiver;
+        eckit::testing::SetEnv env("FDB_CONFIG", config_str.c_str());
+        fdb5::Config conf = fdb5::Config().expandConfig();
+        fdb5::Archiver archiver(conf);
         auto visitor = fdb5::ArchiveVisitor::create(archiver, key, data, 4);
         config.schema().expand(key, *visitor);
         fdb5::TypedKey tKey(visitor->rule()->registry());
@@ -296,7 +308,9 @@ CASE("ClimateMonthly - string ctor - expansion") {
     EXPECT_EQUAL(key.valuesToString(), "op:0001:mnth:g:cl:pl:20210427:0000:50:129.128");
 
     {
-        fdb5::Archiver archiver;
+        eckit::testing::SetEnv env("FDB_CONFIG", config_str.c_str());
+        fdb5::Config conf = fdb5::Config().expandConfig();
+        fdb5::Archiver archiver(conf);
         auto visitor = fdb5::ArchiveVisitor::create(archiver, key, data, 4);
         config.schema().expand(key, *visitor);
         fdb5::TypedKey tKey(visitor->rule()->registry());
@@ -329,7 +343,9 @@ CASE("Date - string ctor - expansion") {
     EXPECT_EQUAL(key.valuesToString(), "od:0001:oper:ofb:" + t(now.yyyymmdd()) + ":0000:mhs:3001");
 
     {
-        fdb5::Archiver archiver;
+        eckit::testing::SetEnv env("FDB_CONFIG", config_str.c_str());
+        fdb5::Config conf = fdb5::Config().expandConfig();
+        fdb5::Archiver archiver(conf);
         auto visitor = fdb5::ArchiveVisitor::create(archiver, key, data, 4);
         config.schema().expand(key, *visitor);
         fdb5::TypedKey tKey(visitor->rule()->registry());


### PR DESCRIPTION
### Description

fixed SelectFDB config & callback propagation 

- it is passing userConfig to the SelectFDB lanes
- it is creating a shared object holding the callback, thus registering the callbacks with the parent object makes them available for all the lanes
- test config is now using selectFDB

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-PUBLISH-FDB_BEGIN -->
🌈🌦️📖🚧 Documentation FDB 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/fdb/pull-requests/PR-349
<!-- PREVIEW-PUBLISH-FDB_END -->